### PR TITLE
Enable stage pointer interactions for card drag

### DIFF
--- a/client/src/gamepixi/StageRoot.tsx
+++ b/client/src/gamepixi/StageRoot.tsx
@@ -4,6 +4,7 @@ import Board from './layers/Board';
 import HandLayer from './layers/Hand';
 import Effects from './layers/Effects';
 import { useApplication } from '@pixi/react';
+import { useEffect } from 'react';
 
 interface StageRootProps {
   state: GameState | null;
@@ -26,6 +27,17 @@ export default function StageRoot({
   canAttack
 }: StageRootProps) {
   const { app } = useApplication();
+  useEffect(() => {
+    const { stage, renderer } = app;
+    const previousEventMode = stage.eventMode;
+    const previousHitArea = stage.hitArea;
+    stage.eventMode = 'static';
+    stage.hitArea = renderer.screen;
+    return () => {
+      stage.eventMode = previousEventMode;
+      stage.hitArea = previousHitArea;
+    };
+  }, [app]);
   window.__PIXI_DEVTOOLS__ = {
     app: app,
   };


### PR DESCRIPTION
## Summary
- enable pointer interactions on the Pixi stage so cards follow the cursor while dragging
- restore the stage's prior pointer configuration on cleanup to avoid side effects

## Testing
- npm run lint -w client

------
https://chatgpt.com/codex/tasks/task_e_68d3dff2920483299ed81a25597d0736