### PR TITLE
Enable spell targeting drag

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -116,17 +116,17 @@ export default function App() {
   );
 
   const handlePlayCard = useCallback(
-    (card: CardInHand) => {
+    (card: CardInHand, explicitTarget?: TargetDescriptor) => {
       if (!side || !canPlayCard(card)) {
         return;
       }
       const opponentSide: PlayerSide = side === 'A' ? 'B' : 'A';
-      let target: { type: 'hero'; side: PlayerSide } | undefined;
-      if (card.card.type === 'Spell') {
+      let target: TargetDescriptor | undefined = explicitTarget;
+      if (!target && card.card.type === 'Spell') {
         if (card.card.effect === 'Firebolt') {
-          target = { type: 'hero', side: opponentSide } as const;
+          target = { type: 'hero', side: opponentSide };
         } else if (card.card.effect === 'Heal') {
-          target = { type: 'hero', side } as const;
+          target = { type: 'hero', side };
         }
       }
       socket.sendWithAck('PlayCard', {

--- a/client/src/gamepixi/StageRoot.tsx
+++ b/client/src/gamepixi/StageRoot.tsx
@@ -9,7 +9,7 @@ import { useEffect } from 'react';
 interface StageRootProps {
   state: GameState | null;
   playerSide: PlayerSide | null;
-  onPlayCard: (card: CardInHand) => void;
+  onPlayCard: (card: CardInHand, target?: TargetDescriptor) => void;
   canPlayCard: (card: CardInHand) => boolean;
   onAttack: (attackerId: string, target: TargetDescriptor) => void;
   canAttack: (minion: MinionEntity) => boolean;
@@ -63,11 +63,12 @@ export default function StageRoot({
           height={HEIGHT}
           onAttack={onAttack}
           canAttack={canAttack}
+          onCastSpell={(card, target) => onPlayCard(card, target)}
         />
         <HandLayer
           hand={player.hand}
           canPlay={canPlayCard}
-          onPlay={onPlayCard}
+          onPlay={(card) => onPlayCard(card)}
           width={WIDTH}
           height={HEIGHT}
         />

--- a/client/src/pixi-react.d.ts
+++ b/client/src/pixi-react.d.ts
@@ -1,0 +1,1 @@
+import '@pixi/react/types/global';

--- a/client/src/state/store.ts
+++ b/client/src/state/store.ts
@@ -1,15 +1,55 @@
+import type { CardInHand, TargetDescriptor } from '@cardstone/shared/types';
 import { create } from 'zustand';
+
+type TargetingSource =
+  | { kind: 'minion'; entityId: string }
+  | { kind: 'spell'; card: CardInHand };
+
+export interface TargetingState {
+  source: TargetingSource;
+  pointerId: number;
+  origin: { x: number; y: number };
+  current: { x: number; y: number };
+}
 
 interface UiState {
   hoveredCard?: string;
   selectedCard?: string;
+  targeting?: TargetingState;
+  currentTarget?: TargetDescriptor | null;
   setHovered: (id?: string) => void;
   setSelected: (id?: string) => void;
+  setTargeting: (targeting?: TargetingState) => void;
+  updateTargeting: (point: { x: number; y: number }) => void;
+  setCurrentTarget: (
+    target:
+      | TargetDescriptor
+      | null
+      | ((prev: TargetDescriptor | null) => TargetDescriptor | null)
+  ) => void;
 }
 
 export const useUiStore = create<UiState>((set) => ({
   hoveredCard: undefined,
   selectedCard: undefined,
+  targeting: undefined,
+  currentTarget: null,
   setHovered: (id) => set({ hoveredCard: id }),
-  setSelected: (id) => set({ selectedCard: id })
+  setSelected: (id) => set({ selectedCard: id }),
+  setTargeting: (targeting) => set({ targeting }),
+  updateTargeting: (point) =>
+    set((state) =>
+      state.targeting
+        ? {
+            targeting: {
+              ...state.targeting,
+              current: point
+            }
+          }
+        : {}
+    ),
+  setCurrentTarget: (target) =>
+    set((state) => ({
+      currentTarget: typeof target === 'function' ? target(state.currentTarget ?? null) : target
+    }))
 }));

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -6,7 +6,7 @@
     "types": ["vite/client"],
     "baseUrl": "./src",
     "paths": {
-      "@cardstone/shared/*": ["../shared/*"]
+      "@cardstone/shared/*": ["../../shared/*"]
     }
   },
   "include": ["src"],


### PR DESCRIPTION
## Summary
- track shared targeting state so the board can render targeting arrows for minions and spells
- start targeted spells from the hand and highlight valid board/hero targets while casting
- pipe selected targets back through StageRoot/App and adjust client config for shared imports

## Testing
- npm run lint -w client

------
https://chatgpt.com/codex/tasks/task_e_68d3e3e1f7d08329bcb2b392a64af2f5