### PR TITLE
Fix minion drag detection and add hover feedback

### DIFF
--- a/client/src/gamepixi/Card.tsx
+++ b/client/src/gamepixi/Card.tsx
@@ -21,6 +21,7 @@ interface CardProps {
   selected?: boolean;
   onDragStart?: (card: CardInHand, event: FederatedPointerEvent) => void;
   onDragEnd?: (card: CardInHand, event: FederatedPointerEvent) => void;
+  scale?: number;
 }
 
 export function Card({
@@ -32,7 +33,8 @@ export function Card({
   disabled,
   selected,
   onDragStart,
-  onDragEnd
+  onDragEnd,
+  scale = 1
 }: CardProps) {
   const costLabel = useMemo(() => `${card.card.cost}`, [card.card.cost]);
   const statsLabel =
@@ -41,6 +43,7 @@ export function Card({
     <pixiContainer
       x={x}
       y={y}
+      scale={scale}
       interactive={!disabled}
       onPointerTap={() => {
         if (!disabled) {

--- a/client/src/gamepixi/layers/Hand.tsx
+++ b/client/src/gamepixi/layers/Hand.tsx
@@ -93,11 +93,12 @@ export default function HandLayer({ hand, canPlay, onPlay, width, height }: Hand
           return undefined;
         }
 
-        const { card, hasMoved } = current;
-        const dropY = event.global.y;
-        const withinDropZone = dropY >= dropZone.top && dropY <= dropZone.bottom;
+        const { card, hasMoved, y: cardY } = current;
+        const cardTop = cardY;
+        const cardBottom = cardY + CARD_SIZE.height;
+        const intersectsDropZone = cardBottom >= dropZone.top && cardTop <= dropZone.bottom;
 
-        if (hasMoved && withinDropZone && canPlay(card)) {
+        if (hasMoved && intersectsDropZone && canPlay(card)) {
           onPlay(card);
           setSelected(undefined);
           playedFromDragRef.current = card.instanceId;
@@ -208,6 +209,10 @@ export default function HandLayer({ hand, canPlay, onPlay, width, height }: Hand
     );
   });
 
+  const isDraggingOverDropZone = dragging
+    ? dragging.y + CARD_SIZE.height >= dropZone.top && dragging.y <= dropZone.bottom
+    : false;
+
   const draggingCard = dragging ? (
     <Card
       key={`${dragging.card.instanceId}-dragging`}
@@ -218,6 +223,7 @@ export default function HandLayer({ hand, canPlay, onPlay, width, height }: Hand
       selected={selected === dragging.card.instanceId}
       onHover={setHovered}
       onClick={handleCardClick}
+      scale={isDraggingOverDropZone ? 0.94 : 1}
     />
   ) : null;
 


### PR DESCRIPTION
## Summary
- ensure dragged minion cards are considered in the drop zone when their bounds overlap the board
- add a scale prop to the Card component and shrink dragged minions slightly when hovering the drop zone for feedback

## Testing
- npm run lint
- npm test *(fails: vitest cannot resolve @cardstone/shared/constants.js without built artifacts)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ffefd1e8832993d80864789d55f7