### PR TITLE
Handle hand drag interactions through Card props

### DIFF
--- a/client/src/gamepixi/Card.tsx
+++ b/client/src/gamepixi/Card.tsx
@@ -21,7 +21,9 @@ interface CardProps {
   selected?: boolean;
   onDragStart?: (card: CardInHand, event: FederatedPointerEvent) => void;
   onDragEnd?: (card: CardInHand, event: FederatedPointerEvent) => void;
+  onDragMove?: (card: CardInHand, event: FederatedPointerEvent) => void;
   scale?: number;
+  zIndex?: number;
 }
 
 export function Card({
@@ -34,7 +36,9 @@ export function Card({
   selected,
   onDragStart,
   onDragEnd,
-  scale = 1
+  onDragMove,
+  scale = 1,
+  zIndex = 0
 }: CardProps) {
   const costLabel = useMemo(() => `${card.card.cost}`, [card.card.cost]);
   const statsLabel =
@@ -44,7 +48,9 @@ export function Card({
       x={x}
       y={y}
       scale={scale}
+      eventMode={disabled ? 'none' : 'static'}
       interactive={!disabled}
+      zIndex={zIndex}
       onPointerTap={() => {
         if (!disabled) {
           onClick(card);
@@ -59,6 +65,11 @@ export function Card({
       onPointerDown={(event) => {
         if (!disabled) {
           onDragStart?.(card, event);
+        }
+      }}
+      onPointerMove={(event) => {
+        if (!disabled) {
+          onDragMove?.(card, event);
         }
       }}
       onPointerUp={(event) => {


### PR DESCRIPTION
## Summary
- add optional drag move handling and z-index support to the Card component so parents can respond to pointer movement directly
- rework the hand layer to rely on Card pointer callbacks for dragging, updating targeting and drop logic without stage-level subscriptions
- route board targeting pointer updates through board-level pointer callbacks instead of renderer-wide subscriptions

## Testing
- npm run lint -w client *(warning about the unsupported TypeScript version in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d40fcb1e9883299f7bd6e26e9e37f7