### PR TITLE
Fix target arrow blocking enemy selection

### DIFF
--- a/client/src/gamepixi/layers/Board.tsx
+++ b/client/src/gamepixi/layers/Board.tsx
@@ -291,6 +291,7 @@ export default function Board({
   const attackIndicator = targeting ? (
     <pixiGraphics
       key="attack-indicator"
+      eventMode="none"
       draw={(g) => {
         g.clear();
         g.lineStyle(4, 0xffeaa7, 0.95);


### PR DESCRIPTION
## Summary
- disable pointer events on the targeting arrow graphics so it no longer intercepts clicks on enemy entities

## Testing
- npm run lint -w client

------
https://chatgpt.com/codex/tasks/task_e_68d4252fcd40832992b8f0eff8825a33