### PR TITLE
Enhance hand hover scaling and board card art

### DIFF
--- a/client/src/gamepixi/layers/Hand.tsx
+++ b/client/src/gamepixi/layers/Hand.tsx
@@ -60,7 +60,6 @@ export default function HandLayer({ hand, canPlay, onPlay, width, height }: Hand
 
   const handleDragMove = useCallback(
     (card: CardInHand, event: FederatedPointerEvent) => {
-      console.log('handleDragMove event:  ', event.global);
       setDragging((prev) => {
         if (!prev || prev.card.instanceId !== card.instanceId || prev.pointerId !== event.pointerId) {
           return prev;
@@ -132,14 +131,11 @@ export default function HandLayer({ hand, canPlay, onPlay, width, height }: Hand
       event: FederatedPointerEvent,
       startPosition: { x: number; y: number }
     ) => {
-      console.log('dragging: ', dragging);
       if (dragging) {
         return;
       }
       playedFromDragRef.current = undefined;
-      console.log('isTargetedSpell(card): ', isTargetedSpell(card));
       if (isTargetedSpell(card)) {
-        console.log('targeting: ', targeting);
         if (targeting) {
           return;
         }
@@ -153,7 +149,6 @@ export default function HandLayer({ hand, canPlay, onPlay, width, height }: Hand
         }
         setSelected(card.instanceId);
         setCurrentTarget(null);
-        console.log('event.global: ', { x: event.global.x, y: event.global.y });
         setTargeting({
           source: { kind: 'spell', card },
           pointerId: event.pointerId,


### PR DESCRIPTION
## Summary
- smoothly scale cards in hand when hovered and emphasize selected cards
- render minions with their card art masked to an egg-like ellipse and add a backdrop for stats
- remove debugging logs from hand interactions

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d43e1d6fa083298ed103cf4e5f9c53