### PR TITLE
Fix board card art mask

### DIFF
--- a/client/src/gamepixi/layers/Board.tsx
+++ b/client/src/gamepixi/layers/Board.tsx
@@ -68,7 +68,6 @@ function MinionCardArt({ cardId }: { cardId: string }) {
       />
       <pixiGraphics
         ref={handleMaskRef}
-        renderable={false}
         draw={(g) => {
           g.clear()
           g.beginFill(0xffffff, 1)


### PR DESCRIPTION
## Summary
- allow the board minion art mask graphic to render so PIXI can apply the stencil correctly

## Testing
- npm run lint -w client

------
https://chatgpt.com/codex/tasks/task_e_68d58a1022f48329b877a41ef6323778