### PR TITLE
Adjust hand card arc to lower outer cards

### DIFF
--- a/client/src/gamepixi/layers/Hand.tsx
+++ b/client/src/gamepixi/layers/Hand.tsx
@@ -7,7 +7,7 @@ import { useUiStore } from '../../state/store';
 
 const MAX_FAN_DEG = 50;
 const FAN_MIX_WEIGHT = 0.72;
-const CARD_OVERLAP = 0.32;
+const CARD_OVERLAP = 0.42;
 const MIN_RADIUS = CARD_SIZE.height * 2.6;
 const HAND_MARGIN_BOTTOM = 20;
 const HAND_MARGIN_LEFT = 50;
@@ -84,7 +84,7 @@ function computeHandLayout(count: number, width: number, height: number): Transf
     const thetaDeg = count === 1 ? 0 : -maxFan / 2 + index * stepDeg;
     const thetaRad = (thetaDeg * Math.PI) / 180;
     const arcX = centerX + radius * Math.sin(thetaRad);
-    const arcY = handBaseY - radius * (1 - Math.cos(thetaRad));
+    const arcY = handBaseY + radius * (1 - Math.cos(thetaRad));
     const linearX = linearStartX + index * linearSpacing;
     const mixedX = arcX * FAN_MIX_WEIGHT + linearX * (1 - FAN_MIX_WEIGHT);
 


### PR DESCRIPTION
## Summary
- lower the outer cards in the player's hand by flipping the arc curvature
- increase hand card overlap so cards sit closer together

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d79b0f79c08329b69fd200ddde6802