### PR TITLE
feat: show opponent hand with card backs

### DIFF
--- a/client/src/gamepixi/StageRoot.tsx
+++ b/client/src/gamepixi/StageRoot.tsx
@@ -2,6 +2,7 @@ import type { CardInHand, GameState, MinionEntity, PlayerSide, TargetDescriptor 
 import Background from './layers/Background';
 import Board from './layers/Board';
 import HandLayer from './layers/Hand';
+import OpponentHandLayer from './layers/OpponentHand';
 import Effects from './layers/Effects';
 import { useApplication } from '@pixi/react';
 import { useEffect, useMemo } from 'react';
@@ -81,6 +82,8 @@ export default function StageRoot({
     );
   }
   const player = state.players[playerSide];
+  const opponentSide: PlayerSide = playerSide === 'A' ? 'B' : 'A';
+  const opponent = state.players[opponentSide];
 
   return (
     <pixiContainer width={targetWidth} height={targetHeight} options={{ backgroundAlpha: 0 }}>
@@ -99,6 +102,11 @@ export default function StageRoot({
           hand={player.hand}
           canPlay={canPlayCard}
           onPlay={(card) => onPlayCard(card)}
+          width={targetWidth}
+          height={targetHeight}
+        />
+        <OpponentHandLayer
+          count={opponent.hand.length}
           width={targetWidth}
           height={targetHeight}
         />

--- a/client/src/gamepixi/layers/Hand.tsx
+++ b/client/src/gamepixi/layers/Hand.tsx
@@ -66,7 +66,7 @@ function approach(current: number, target: number, factor: number): number {
   return current + diff * factor;
 }
 
-function computeHandLayout(count: number, width: number, height: number): Transform[] {
+export function computeHandLayout(count: number, width: number, height: number): Transform[] {
   if (count === 0) {
     return [];
   }

--- a/client/src/gamepixi/layers/OpponentHand.tsx
+++ b/client/src/gamepixi/layers/OpponentHand.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Assets, Texture } from 'pixi.js';
+
+import { CARD_SIZE } from '../Card';
+import { computeHandLayout } from './Hand';
+
+interface OpponentHandProps {
+  count: number;
+  width: number;
+  height: number;
+}
+
+const CARD_BACK_TEXTURE = '/assets/card_skins/1.webp';
+
+export default function OpponentHandLayer({ count, width, height }: OpponentHandProps) {
+  const [texture, setTexture] = useState(Texture.EMPTY);
+
+  useEffect(() => {
+    if (texture !== Texture.EMPTY) {
+      return;
+    }
+    let cancelled = false;
+    Assets.load(CARD_BACK_TEXTURE).then((result) => {
+      if (!cancelled) {
+        setTexture(result);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [texture]);
+
+  const positions = useMemo(() => {
+    const layout = computeHandLayout(count, width, height);
+    return layout.map((base) => ({
+      x: base.x,
+      y: CARD_SIZE.height + (height - base.y),
+      rotation: -base.rotation,
+      scale: base.scale,
+      z: base.z,
+    }));
+  }, [count, height, width]);
+
+  if (count === 0) {
+    return null;
+  }
+
+  return (
+    <pixiContainer sortableChildren eventMode="none">
+      {positions.map((pos, index) => (
+        <pixiContainer
+          key={index}
+          x={pos.x}
+          y={pos.y}
+          rotation={pos.rotation}
+          scale={pos.scale}
+          pivot={{ x: CARD_SIZE.width / 2, y: CARD_SIZE.height }}
+          zIndex={pos.z}
+        >
+          <pixiSprite texture={texture} width={CARD_SIZE.width} height={CARD_SIZE.height} />
+        </pixiContainer>
+      ))}
+    </pixiContainer>
+  );
+}


### PR DESCRIPTION
## Summary
- add an opponent hand layer that mirrors the player hand positioning and renders card backs
- expose the hand layout helper for reuse when drawing the opponent hand
- wire the opponent hand into the stage so the top of the screen shows the opponent's cards

## Testing
- npm run lint -w client

------
https://chatgpt.com/codex/tasks/task_e_68d7ac2ad54c8329b382bd2cb2f78b4c