### PR TITLE
Center board minions and support left/right placement

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type {
   CardInHand,
+  CardPlacement,
   GameState,
   MinionEntity,
   PlayerSide,
@@ -154,7 +155,12 @@ export default function App() {
   );
 
   const handlePlayCard = useCallback(
-    (card: CardInHand, explicitTarget?: TargetDescriptor) => {
+    (
+      card: CardInHand,
+      options?: { target?: TargetDescriptor; placement?: CardPlacement }
+    ) => {
+      const explicitTarget = options?.target;
+      const placement = options?.placement;
       if (!side || !canPlayCard(card)) {
         return;
       }
@@ -169,7 +175,8 @@ export default function App() {
       }
       socket.sendWithAck('PlayCard', {
         cardId: card.instanceId,
-        ...(target ? { target } : {})
+        ...(target ? { target } : {}),
+        ...(placement ? { placement } : {})
       });
     },
     [canPlayCard, side, socket]

--- a/client/src/gamepixi/StageRoot.tsx
+++ b/client/src/gamepixi/StageRoot.tsx
@@ -1,4 +1,11 @@
-import type { CardInHand, GameState, MinionEntity, PlayerSide, TargetDescriptor } from '@cardstone/shared/types';
+import type {
+  CardInHand,
+  CardPlacement,
+  GameState,
+  MinionEntity,
+  PlayerSide,
+  TargetDescriptor
+} from '@cardstone/shared/types';
 import Background from './layers/Background';
 import Board from './layers/Board';
 import HandLayer from './layers/Hand';
@@ -9,7 +16,10 @@ import { useEffect, useMemo } from 'react';
 interface StageRootProps {
   state: GameState | null;
   playerSide: PlayerSide | null;
-  onPlayCard: (card: CardInHand, target?: TargetDescriptor) => void;
+  onPlayCard: (
+    card: CardInHand,
+    options?: { target?: TargetDescriptor; placement?: CardPlacement }
+  ) => void;
   canPlayCard: (card: CardInHand) => boolean;
   onAttack: (attackerId: string, target: TargetDescriptor) => void;
   canAttack: (minion: MinionEntity) => boolean;
@@ -93,12 +103,13 @@ export default function StageRoot({
           height={targetHeight}
           onAttack={onAttack}
           canAttack={canAttack}
-          onCastSpell={(card, target) => onPlayCard(card, target)}
+          onCastSpell={(card, target) => onPlayCard(card, { target })}
         />
         <HandLayer
           hand={player.hand}
           canPlay={canPlayCard}
-          onPlay={(card) => onPlayCard(card)}
+          onPlay={(card, options) => onPlayCard(card, options)}
+          boardMinionCount={state.board[playerSide].length}
           width={targetWidth}
           height={targetHeight}
         />

--- a/client/src/gamepixi/layers/Board.tsx
+++ b/client/src/gamepixi/layers/Board.tsx
@@ -256,8 +256,12 @@ export default function Board({
   const renderRow = useCallback(
     (side: PlayerSide, y: number) => {
       const minions = state.board[side];
+      const count = minions.length;
+      const rowWidth =
+        count > 0 ? count * MINION_WIDTH + (count - 1) * MINION_HORIZONTAL_GAP : 0;
+      const startX = laneX + (laneWidth - rowWidth) / 2;
       return minions.map((entity, index) => {
-        const x = laneX + index * (MINION_WIDTH + MINION_HORIZONTAL_GAP);
+        const x = startX + index * (MINION_WIDTH + MINION_HORIZONTAL_GAP);
         const isFriendly = side === playerSide;
         const canAttackThisMinion = isFriendly && canAttack(entity);
         const targetDescriptor: TargetDescriptor = {
@@ -361,13 +365,13 @@ export default function Board({
               text={`${entity.attack}`}
               x={MINION_WIDTH * 0.12}
               y={MINION_HEIGHT * 0.7}
-              style={{ fill: 0xFFFFFF, fontSize: 24, fontWeight: 'bold' }}
+              style={{ fill: 0xffffff, fontSize: 24, fontWeight: 'bold' }}
             />
             <pixiText
               text={`${entity.health}`}
               x={MINION_WIDTH * 0.8}
               y={MINION_HEIGHT * 0.7}
-              style={{ fill: 0xFFFFFF, fontSize: 24, fontWeight: 'bold' }}
+              style={{ fill: 0xffffff, fontSize: 24, fontWeight: 'bold' }}
             />
           </pixiContainer>
         );
@@ -380,6 +384,7 @@ export default function Board({
       handleTargetOut,
       handleTargetOver,
       laneX,
+      laneWidth,
       minionAnimations,
       playerSide,
       state.board,

--- a/client/src/gamepixi/layout.ts
+++ b/client/src/gamepixi/layout.ts
@@ -35,11 +35,15 @@ export function getBoardLaneGeometry(width: number, height: number): BoardLaneGe
 function computeRowPositions(
   minions: MinionEntity[],
   laneX: number,
+  laneWidth: number,
   y: number
 ): Record<string, EntityPosition> {
   const positions: Record<string, EntityPosition> = {};
+  const count = minions.length;
+  const rowWidth = count > 0 ? count * MINION_WIDTH + (count - 1) * MINION_HORIZONTAL_GAP : 0;
+  const startX = laneX + (laneWidth - rowWidth) / 2;
   minions.forEach((entity, index) => {
-    const x = laneX + index * (MINION_WIDTH + MINION_HORIZONTAL_GAP);
+    const x = startX + index * (MINION_WIDTH + MINION_HORIZONTAL_GAP);
     positions[entity.instanceId] = {
       x: x + MINION_WIDTH / 2,
       y: y + MINION_HEIGHT / 2
@@ -62,8 +66,18 @@ export function computeBoardLayout(
     B: {}
   };
 
-  minions[playerSide] = computeRowPositions(state.board[playerSide], geometry.laneX, geometry.boardBottomY);
-  minions[opponentSide] = computeRowPositions(state.board[opponentSide], geometry.laneX, geometry.boardTopY);
+  minions[playerSide] = computeRowPositions(
+    state.board[playerSide],
+    geometry.laneX,
+    geometry.laneWidth,
+    geometry.boardBottomY
+  );
+  minions[opponentSide] = computeRowPositions(
+    state.board[opponentSide],
+    geometry.laneX,
+    geometry.laneWidth,
+    geometry.boardTopY
+  );
 
   const heroes: Record<PlayerSide, EntityPosition> = {
     A:

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -197,7 +197,8 @@ async function handleClientMessage(
         message.seq!,
         message.nonce!,
         message.payload.cardId,
-        message.payload.target
+        message.payload.target,
+        message.payload.placement
       );
       sendMessage(context, { t: 'ActionResult', seq: message.seq, payload: result });
       if (result.stateChanged) {

--- a/server/src/match/Match.ts
+++ b/server/src/match/Match.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import type { GameState, PlayerSide, TargetDescriptor } from '@cardstone/shared/types';
+import type { CardPlacement, GameState, PlayerSide, TargetDescriptor } from '@cardstone/shared/types';
 import { CARD_IDS, DEFAULT_DECK, MATCH_CONFIG, STARTING_SEQ } from '@cardstone/shared/constants';
 import { getCardDefinition } from '@cardstone/shared/cards/demo';
 import { createRng, createSeed, shuffleInPlace, type RNG } from '../util/rng.js';
@@ -127,7 +127,8 @@ export class Match {
     seq: number,
     nonce: string,
     cardInstanceId: string,
-    target?: TargetDescriptor
+    target?: TargetDescriptor,
+    placement?: CardPlacement
   ): CommandResult {
     const side = this.requireSide(playerId);
     const meta = this.players[side];
@@ -136,8 +137,8 @@ export class Match {
       if (duplicate) {
         return { ok: true, stateChanged: false, duplicate: true };
       }
-      validatePlayCard(this.state, side, cardInstanceId, target);
-      applyPlayCard(this.state, side, cardInstanceId, target);
+      validatePlayCard(this.state, side, cardInstanceId, target, placement);
+      applyPlayCard(this.state, side, cardInstanceId, target, placement);
       this.bumpSeq();
       return { ok: true, stateChanged: true };
     } catch (error) {

--- a/server/src/match/reducer.ts
+++ b/server/src/match/reducer.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import {
+  type CardPlacement,
   type GameState,
   type MinionCard,
   type PlayerSide,
@@ -58,7 +59,8 @@ export function applyPlayCard(
   state: GameState,
   side: PlayerSide,
   cardInstanceId: string,
-  target?: TargetDescriptor
+  target?: TargetDescriptor,
+  placement?: CardPlacement
 ): void {
   const player = state.players[side];
   const handIndex = player.hand.findIndex((card) => card.instanceId === cardInstanceId);
@@ -73,21 +75,33 @@ export function applyPlayCard(
   player.hand.splice(handIndex, 1);
 
   if (handCard.card.type === 'Minion') {
-    summonMinion(state, side, handCard.card);
+    summonMinion(state, side, handCard.card, placement);
   } else {
     resolveSpell(state, side, handCard.card, target);
     player.graveyard.push(handCard.card.id);
   }
 }
 
-function summonMinion(state: GameState, side: PlayerSide, card: MinionCard): void {
-  state.board[side].push({
+function summonMinion(
+  state: GameState,
+  side: PlayerSide,
+  card: MinionCard,
+  placement: CardPlacement | undefined
+): void {
+  const minion = {
     instanceId: randomUUID(),
     card,
     attack: card.attack,
     health: card.health,
     attacksRemaining: 1
-  });
+  };
+
+  if (placement === 'left') {
+    state.board[side].unshift(minion);
+    return;
+  }
+
+  state.board[side].push(minion);
 }
 
 function resolveSpell(

--- a/server/src/match/validate.ts
+++ b/server/src/match/validate.ts
@@ -1,4 +1,10 @@
-import type { GameState, PlayerSide, SpellCard, TargetDescriptor } from '@cardstone/shared/types.js';
+import type {
+  CardPlacement,
+  GameState,
+  PlayerSide,
+  SpellCard,
+  TargetDescriptor
+} from '@cardstone/shared/types.js';
 import { getTargetingPredicate } from '@cardstone/shared/targeting';
 
 export class ValidationError extends Error {
@@ -18,7 +24,8 @@ export function validatePlayCard(
   state: GameState,
   side: PlayerSide,
   cardInstanceId: string,
-  target?: TargetDescriptor
+  target?: TargetDescriptor,
+  _placement?: CardPlacement
 ): void {
   assertPlayersTurn(state, side);
   if (state.turn.phase !== 'Main') {

--- a/server/src/net/protocol.ts
+++ b/server/src/net/protocol.ts
@@ -25,6 +25,7 @@ const targetSchema: z.ZodType<TargetDescriptor> = z.discriminatedUnion('type', [
 
 const nonce = () => z.string().min(8).max(64);
 const seq = () => z.number().int().nonnegative();
+const placementSchema = z.enum(['left', 'right']);
 
 export const clientMessageSchema = z.discriminatedUnion('t', [
   z.object({
@@ -37,7 +38,11 @@ export const clientMessageSchema = z.discriminatedUnion('t', [
   }),
   z.object({
     t: z.literal('PlayCard'),
-    payload: z.object({ cardId: z.string(), target: targetSchema.optional() }),
+    payload: z.object({
+      cardId: z.string(),
+      target: targetSchema.optional(),
+      placement: placementSchema.optional()
+    }),
     seq: seq(),
     nonce: nonce()
   }),

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -6,6 +6,8 @@ export type CardId = string;
 
 export type CardType = 'Minion' | 'Spell';
 
+export type CardPlacement = 'left' | 'right';
+
 export interface CardBase {
   id: CardId;
   name: string;
@@ -94,7 +96,7 @@ export type CommandBase<T extends string, P> = {
 };
 
 export type Command =
-  | CommandBase<'PlayCard', { cardId: EntityId; target?: TargetDescriptor }>
+  | CommandBase<'PlayCard', { cardId: EntityId; target?: TargetDescriptor; placement?: CardPlacement }>
   | CommandBase<'EndTurn', Record<string, never>>
   | CommandBase<'Attack', { attackerId: EntityId; target: TargetDescriptor }>
   | CommandBase<'Ready', object>;
@@ -131,7 +133,7 @@ export interface ClientMessageBase<T extends string, P> {
 export type ClientToServer =
   | ClientMessageBase<'JoinMatch', { matchId: 'auto' | string; playerId?: string }>
   | ClientMessageBase<'Ready', { playerId?: string }>
-  | ClientMessageBase<'PlayCard', { cardId: EntityId; target?: TargetDescriptor }>
+  | ClientMessageBase<'PlayCard', { cardId: EntityId; target?: TargetDescriptor; placement?: CardPlacement }>
   | ClientMessageBase<'EndTurn', Record<string, never>>
   | ClientMessageBase<'Attack', { attackerId: EntityId; target: TargetDescriptor }>
   | ClientMessageBase<'Emote', { type: 'Hello' | 'WellPlayed' | 'Oops' }>;


### PR DESCRIPTION
## Summary
- add a CardPlacement payload to PlayCard commands and propagate it through shared types, server validation, and summoning logic
- update the client hand interactions to detect drop position, forward placement hints, and pass board minion counts through StageRoot
- center minion rendering and layout on the board so creatures fan out symmetrically around the lane center

## Testing
- npm run lint -w shared
- npm run lint -w server
- npm run lint -w client

------
https://chatgpt.com/codex/tasks/task_e_68d7ac7dbda083299c84d7e8a088ede4