### PR TITLE
Adjust hand card and board minion proportions

### DIFF
--- a/client/src/gamepixi/layers/Hand.tsx
+++ b/client/src/gamepixi/layers/Hand.tsx
@@ -9,11 +9,17 @@ import { getBoardLaneGeometry } from '../layout';
 const MAX_FAN_DEG = 50;
 const FAN_MIX_WEIGHT = 0.72;
 const CARD_OVERLAP = 0.42;
-const MIN_RADIUS = CARD_SIZE.height * 2.6;
+const BASE_CARD_SCALE = 0.8;
+export const HAND_BASE_SCALE = BASE_CARD_SCALE;
+export const HAND_CARD_DIMENSIONS = {
+  width: CARD_SIZE.width * BASE_CARD_SCALE,
+  height: CARD_SIZE.height * BASE_CARD_SCALE
+};
+const MIN_RADIUS = HAND_CARD_DIMENSIONS.height * 2.6;
 const HAND_MARGIN_BOTTOM = 20;
 const HAND_MARGIN_LEFT = 50;
 const HOVER_LIFT = 42;
-const HOVER_SCALE = 1.1;
+const HOVER_SCALE = 1.32;
 const HOVER_Z_INDEX = 9999;
 const DRAG_Z_INDEX = HOVER_Z_INDEX + 1;
 const HOVER_SPEED = 0.5;
@@ -78,7 +84,7 @@ export function computeHandLayout(count: number, width: number, height: number):
   const stepDeg = count > 1 ? maxFan / (count - 1) : 0;
   const radiusBase = Math.min(width, height) * 0.65;
   const radius = Math.max(MIN_RADIUS, radiusBase);
-  const linearSpacing = CARD_SIZE.width * (1 - CARD_OVERLAP);
+  const linearSpacing = HAND_CARD_DIMENSIONS.width * (1 - CARD_OVERLAP);
   const linearStartX = centerX - ((count - 1) * linearSpacing) / 2;
 
   return new Array(count).fill(null).map((_, index) => {
@@ -93,7 +99,7 @@ export function computeHandLayout(count: number, width: number, height: number):
       x: mixedX,
       y: arcY,
       rotation: thetaRad,
-      scale: 1,
+      scale: BASE_CARD_SCALE,
       z: index
     };
   });

--- a/client/src/gamepixi/layers/OpponentHand.tsx
+++ b/client/src/gamepixi/layers/OpponentHand.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import { Assets, Texture } from 'pixi.js';
 
 import { CARD_SIZE } from '../Card';
-import { computeHandLayout } from './Hand';
+import { computeHandLayout, HAND_BASE_SCALE } from './Hand';
 
 interface OpponentHandProps {
   count: number;
@@ -34,7 +34,7 @@ export default function OpponentHandLayer({ count, width, height }: OpponentHand
     const layout = computeHandLayout(count, width, height);
     return layout.map((base) => ({
       x: base.x,
-      y: CARD_SIZE.height + (height - base.y),
+      y: CARD_SIZE.height * HAND_BASE_SCALE + (height - base.y),
       rotation: -base.rotation,
       scale: base.scale,
       z: base.z,

--- a/client/src/gamepixi/layout.ts
+++ b/client/src/gamepixi/layout.ts
@@ -1,10 +1,12 @@
 import type { GameState, MinionEntity, PlayerSide } from '@cardstone/shared/types';
 
-export const MINION_WIDTH = 120;
-export const MINION_HEIGHT = 140;
+export const MINION_WIDTH = 96;
+export const MINION_HEIGHT = 112;
 export const MINION_ART_INSET_X = 2;
 export const MINION_ART_INSET_Y = 6;
 export const MINION_HORIZONTAL_GAP = 20;
+const PLAYER_HORIZONTAL_SHIFT_RATIO = 0.1;
+const PLAYER_VERTICAL_SHIFT_RATIO = 0.05;
 
 export interface BoardLaneGeometry {
   boardTopY: number;
@@ -68,9 +70,9 @@ export function computeBoardLayout(
 
   minions[playerSide] = computeRowPositions(
     state.board[playerSide],
-    geometry.laneX,
+    geometry.laneX - geometry.laneWidth * PLAYER_HORIZONTAL_SHIFT_RATIO,
     geometry.laneWidth,
-    geometry.boardBottomY
+    geometry.boardBottomY - height * PLAYER_VERTICAL_SHIFT_RATIO
   );
   minions[opponentSide] = computeRowPositions(
     state.board[opponentSide],


### PR DESCRIPTION
## Summary
- reduce card scale in both hands and increase the hover enlargement effect
- mirror the opponent hand layout using the new card scale
- shrink board minions and adjust the friendly row position upward and leftward

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d7f821a5448329b84b6ccb9d1c59ee