### PR TITLE
Adjust hovered minion preview placement

### DIFF
--- a/client/src/gamepixi/layers/Board.tsx
+++ b/client/src/gamepixi/layers/Board.tsx
@@ -429,7 +429,15 @@ export default function Board({
       const widthWithScale = MINION_WIDTH * scale;
       const heightWithScale = MINION_HEIGHT * scale;
 
-      const previewX = baseX + offsetX + widthWithScale + 10 + CARD_SIZE.width / 2;
+      const previewScale = 1.3;
+      const previewGap = 10 * 0.2;
+
+      const previewX =
+        baseX +
+        offsetX +
+        widthWithScale +
+        previewGap +
+        (CARD_SIZE.width * previewScale) / 2;
       const previewY = baseY + offsetY + heightWithScale;
 
       const previewCard: CardInHand = {
@@ -440,7 +448,8 @@ export default function Board({
       return {
         card: previewCard,
         x: previewX,
-        y: previewY
+        y: previewY,
+        scale: previewScale
       };
     }
 
@@ -557,6 +566,7 @@ export default function Board({
           x={hoveredMinionPreview.x}
           y={hoveredMinionPreview.y}
           rotation={0}
+          scale={hoveredMinionPreview.scale}
           disabled
           eventMode="none"
           cursor="default"


### PR DESCRIPTION
## Summary
- move hovered minion previews to the right of the minion with a much smaller gap
- enlarge the hovered card preview for better readability

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d803afdaa083299df19ae9e2b337d1