### PR TITLE
Adjust hand layout curvature and positioning

### DIFF
--- a/client/src/gamepixi/layers/OpponentHand.tsx
+++ b/client/src/gamepixi/layers/OpponentHand.tsx
@@ -32,9 +32,10 @@ export default function OpponentHandLayer({ count, width, height }: OpponentHand
 
   const positions = useMemo(() => {
     const layout = computeHandLayout(count, width, height);
+    const verticalOffset = CARD_SIZE.height * HAND_BASE_SCALE * 0.5;
     return layout.map((base) => ({
       x: base.x,
-      y: CARD_SIZE.height * HAND_BASE_SCALE + (height - base.y),
+      y: CARD_SIZE.height * HAND_BASE_SCALE + (height - base.y) - verticalOffset,
       rotation: -base.rotation,
       scale: base.scale,
       z: base.z,


### PR DESCRIPTION
## Summary
- add layout configuration options to flatten the player hand arc and drop it slightly lower
- shift the opponent hand positions upward for better spacing while reusing the shared layout helper

## Testing
- npm run build -w client *(fails: shared package types need to be built first in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d80aab31a88329ac5bb7987dba7605