### PR TITLE
Add deck template sprite to background

### DIFF
--- a/client/src/gamepixi/layers/Background.tsx
+++ b/client/src/gamepixi/layers/Background.tsx
@@ -11,17 +11,7 @@ export default function Background({ width, height }: BackgroundProps) {
 
   return (
     <>
-      <pixiGraphics
-        draw={(g) => {
-          g.clear();
-          g.beginFill(0x2d3436);
-          g.drawRect(0, 0, width, height);
-          g.endFill();
-          g.beginFill(0x3e2723, 0.5);
-          g.drawRoundedRect(32, 32, width - 64, height - 64, 24);
-          g.endFill();
-        }}
-      />
+      <pixiSprite image="/assets/board_template.webp" width={width} height={height} />
       <pixiSprite
         image="/assets/deck_template.webp"
         width={deckWidth}

--- a/client/src/gamepixi/layers/Background.tsx
+++ b/client/src/gamepixi/layers/Background.tsx
@@ -4,17 +4,31 @@ interface BackgroundProps {
 }
 
 export default function Background({ width, height }: BackgroundProps) {
+  const deckWidth = 1100;
+  const deckHeight = 650;
+  const deckX = (width - deckWidth) / 2;
+  const deckY = (height - deckHeight) / 2;
+
   return (
-    <pixiGraphics
-      draw={(g) => {
-        g.clear();
-        g.beginFill(0x2d3436);
-        g.drawRect(0, 0, width, height);
-        g.endFill();
-        g.beginFill(0x3e2723, 0.5);
-        g.drawRoundedRect(32, 32, width - 64, height - 64, 24);
-        g.endFill();
-      }}
-    />
+    <>
+      <pixiGraphics
+        draw={(g) => {
+          g.clear();
+          g.beginFill(0x2d3436);
+          g.drawRect(0, 0, width, height);
+          g.endFill();
+          g.beginFill(0x3e2723, 0.5);
+          g.drawRoundedRect(32, 32, width - 64, height - 64, 24);
+          g.endFill();
+        }}
+      />
+      <pixiSprite
+        image="/assets/deck_template.webp"
+        width={deckWidth}
+        height={deckHeight}
+        x={deckX}
+        y={deckY}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- render the deck template image centered on the table background at 1100x650 pixels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d98763590c8329bb50bd3feb03f26d