### PR TITLE
Animate attacks immediately and align hero targets

### DIFF
--- a/client/src/gamepixi/layout.ts
+++ b/client/src/gamepixi/layout.ts
@@ -82,14 +82,14 @@ export function computeBoardLayout(
   );
 
   const heroes: Record<PlayerSide, EntityPosition> = {
-    A:
-      playerSide === 'A'
-        ? { x: 40, y: geometry.boardBottomY + MINION_HEIGHT - 20 }
-        : { x: 40, y: geometry.boardTopY - 80 },
-    B:
-      playerSide === 'B'
-        ? { x: 40, y: geometry.boardBottomY + MINION_HEIGHT - 20 }
-        : { x: 40, y: geometry.boardTopY - 80 }
+    [playerSide]: {
+      x: geometry.laneX + geometry.laneWidth / 2 - 5,
+      y: geometry.boardBottomY + MINION_HEIGHT + 70
+    },
+    [opponentSide]: {
+      x: geometry.laneX + geometry.laneWidth / 2 - 10,
+      y: geometry.boardTopY - 100
+    }
   };
 
   return { minions, heroes };


### PR DESCRIPTION
## Summary
- queue local attack animations before sending attacks to the server so minions lunge even if the target dies
- let the effects layer consume queued animations and reuse the existing tween logic while avoiding duplicate commands
- align hero layout coordinates with their rendered avatars so attacks aim at the portraits

## Testing
- npm run lint -w client *(fails: existing lint warnings in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68dc3aefc7dc832987400f6d48b67709