### PR TITLE
Fix hovered minion preview alignment

### DIFF
--- a/client/src/gamepixi/layers/Board.tsx
+++ b/client/src/gamepixi/layers/Board.tsx
@@ -535,7 +535,11 @@ export default function Board({
       }
 
       const entity = minions[index];
-      const baseX = laneX + index * (MINION_WIDTH + MINION_HORIZONTAL_GAP);
+      const count = minions.length;
+      const rowWidth =
+        count > 0 ? count * MINION_WIDTH + (count - 1) * MINION_HORIZONTAL_GAP : 0;
+      const startX = laneX + (laneWidth - rowWidth) / 2;
+      const baseX = startX + index * (MINION_WIDTH + MINION_HORIZONTAL_GAP);
       const baseY = side === playerSide ? boardBottomY : boardTopY;
       const animation = minionAnimations[entity.instanceId];
       const offsetX = animation?.offsetX ?? 0;


### PR DESCRIPTION
## Summary
- align the hovered minion preview card with the centered row position so it appears next to the source minion

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dc3b298e508329a63852cc9d20bb2b