### PR TITLE
Align attack animations with target centers

### DIFF
--- a/client/src/gamepixi/layout.ts
+++ b/client/src/gamepixi/layout.ts
@@ -5,8 +5,6 @@ export const MINION_HEIGHT = 112;
 export const MINION_ART_INSET_X = 2;
 export const MINION_ART_INSET_Y = 6;
 export const MINION_HORIZONTAL_GAP = 20;
-const PLAYER_HORIZONTAL_SHIFT_RATIO = 0.1;
-const PLAYER_VERTICAL_SHIFT_RATIO = 0.05;
 
 export interface BoardLaneGeometry {
   boardTopY: number;
@@ -70,9 +68,9 @@ export function computeBoardLayout(
 
   minions[playerSide] = computeRowPositions(
     state.board[playerSide],
-    geometry.laneX - geometry.laneWidth * PLAYER_HORIZONTAL_SHIFT_RATIO,
+    geometry.laneX,
     geometry.laneWidth,
-    geometry.boardBottomY - height * PLAYER_VERTICAL_SHIFT_RATIO
+    geometry.boardBottomY
   );
   minions[opponentSide] = computeRowPositions(
     state.board[opponentSide],


### PR DESCRIPTION
## Summary
- align computed board layout positions with the actual board rendering for both sides
- ensure attack animations lunge towards the true center of their targets

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68de7214399083298cb2ae70918a17f3