### PR TITLE
Prevent zero-attack minions from initiating combat

### DIFF
--- a/client/src/components/Game.tsx
+++ b/client/src/components/Game.tsx
@@ -199,6 +199,9 @@ export function Game() {
       if (state.turn.current !== side || state.turn.phase !== 'Main') {
         return false;
       }
+      if (minion.attack <= 0) {
+        return false;
+      }
       return minion.attacksRemaining > 0;
     },
     [side, state]

--- a/server/src/match/reducer.ts
+++ b/server/src/match/reducer.ts
@@ -211,6 +211,9 @@ export function applyAttack(
   if (!attacker) {
     throw new Error('Attacker not found');
   }
+  if (attacker.attack <= 0) {
+    throw new Error('Attacker cannot attack');
+  }
   if (attacker.attacksRemaining <= 0) {
     throw new Error('Attacker has no attacks remaining');
   }

--- a/server/src/match/validate.ts
+++ b/server/src/match/validate.ts
@@ -96,6 +96,9 @@ export function validateAttack(
   if (!attacker) {
     throw new ValidationError('Attacking minion not found');
   }
+  if (attacker.attack <= 0) {
+    throw new ValidationError('This minion cannot attack');
+  }
   if (attacker.attacksRemaining <= 0) {
     throw new ValidationError('This minion has already attacked');
   }


### PR DESCRIPTION
## Summary
- block initiating attacks from client UI when a minion's attack stat is zero or below
- add server-side validation and reducer safeguards so zero-attack minions cannot attack

## Testing
- npm test *(fails: vitest cannot resolve @cardstone/shared/constants.js in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68de7223310c832993810a32db9a259b