### PR TITLE
Implement take card summon effect

### DIFF
--- a/server/src/match/reducer.ts
+++ b/server/src/match/reducer.ts
@@ -3,6 +3,7 @@ import {
   type CardPlacement,
   type GameState,
   type MinionCard,
+  type MinionEntity,
   type PlayerSide,
   type SpellCard,
   type TargetDescriptor
@@ -98,10 +99,21 @@ function summonMinion(
 
   if (placement === 'left') {
     state.board[side].unshift(minion);
-    return;
+  } else {
+    state.board[side].push(minion);
   }
 
-  state.board[side].push(minion);
+  applySummonEffects(state, side, minion);
+}
+
+function applySummonEffects(state: GameState, side: PlayerSide, minion: MinionEntity): void {
+  switch (minion.card.effect) {
+    case 'take_card':
+      drawCard(state, side);
+      break;
+    default:
+      break;
+  }
 }
 
 function resolveSpell(

--- a/tests/match.reducer.test.ts
+++ b/tests/match.reducer.test.ts
@@ -111,6 +111,19 @@ describe('match reducer', () => {
     expect(state.players.A.mana.temporary).toBe(1);
   });
 
+  it('draws a card when summoning a take_card minion', () => {
+    const state = createState();
+    const instanceId = addCard(state, 'A', CARD_IDS.hoarder);
+    state.players.A.deck = [CARD_IDS.knight];
+    state.players.A.mana = { current: 2, max: 2 };
+
+    applyPlayCard(state, 'A', instanceId);
+
+    expect(state.players.A.hand).toHaveLength(1);
+    expect(state.players.A.hand[0]?.card.id).toBe(CARD_IDS.knight);
+    expect(state.players.A.deck).toHaveLength(0);
+  });
+
   it('rejects playing cards without enough mana', () => {
     const state = createState();
     const instanceId = addCard(state, 'A', CARD_IDS.miniDragon);


### PR DESCRIPTION
## Summary
- draw a card for the acting player when a minion with the take_card effect is summoned
- cover the new summon behaviour with a reducer unit test

## Testing
- npm run build -w shared
- npm run build -w server
- npm test --prefix tests

------
https://chatgpt.com/codex/tasks/task_e_68e16eef5a7c83299178b7fe57c54f14