### PR TITLE
Implement divide shield damage prevention

### DIFF
--- a/client/src/gamepixi/layers/Board.tsx
+++ b/client/src/gamepixi/layers/Board.tsx
@@ -550,6 +550,20 @@ export default function Board({
                 g.endFill();
               }}
             />
+            {entity.divineShield ? (
+              <pixiGraphics
+                draw={(g) => {
+                  g.clear();
+                  g.lineStyle(4, 0xfff4aa, 0.9);
+                  g.drawEllipse(
+                    MINION_WIDTH / 2,
+                    MINION_HEIGHT / 2,
+                    MINION_WIDTH / 2 - 4,
+                    MINION_HEIGHT / 2 - 4
+                  );
+                }}
+              />
+            ) : null}
             <MinionCardArt cardId={entity.card.id} />
             <pixiText
               text={`${entity.attack}`}

--- a/server/src/match/reducer.ts
+++ b/server/src/match/reducer.ts
@@ -3,6 +3,7 @@ import {
   type CardPlacement,
   type GameState,
   type MinionCard,
+  type MinionEntity,
   type PlayerSide,
   type SpellCard,
   type TargetDescriptor
@@ -88,12 +89,13 @@ function summonMinion(
   card: MinionCard,
   placement: CardPlacement | undefined
 ): void {
-  const minion = {
+  const minion: MinionEntity = {
     instanceId: randomUUID(),
     card,
     attack: card.attack,
     health: card.health,
-    attacksRemaining: 0
+    attacksRemaining: 0,
+    divineShield: card.effect === 'divide_shield'
   };
 
   if (placement === 'left') {
@@ -159,6 +161,10 @@ function applyDamage(state: GameState, target: TargetDescriptor, amount: number,
   const entity = minions.find((m) => m.instanceId === target.entityId);
   if (!entity) {
     throw new Error('Target minion missing');
+  }
+  if (amount > 0 && entity.divineShield) {
+    entity.divineShield = false;
+    return;
   }
   entity.health -= amount;
   if (entity.health <= 0) {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -48,6 +48,7 @@ export interface MinionEntity {
   attack: number;
   health: number;
   attacksRemaining: number;
+  divineShield?: boolean;
 }
 
 export interface HeroState {

--- a/tests/match.reducer.test.ts
+++ b/tests/match.reducer.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { CARD_IDS, MATCH_CONFIG } from '@cardstone/shared/constants.js';
 import type { GameState, MinionCard, PlayerSide } from '@cardstone/shared/types.js';
 import { getCardDefinition } from '@cardstone/shared/cards/demo.js';
-import { applyPlayCard, gainMana, startTurn } from '@cardstone/server/match/reducer.js';
+import { applyAttack, applyPlayCard, gainMana, startTurn } from '@cardstone/server/match/reducer.js';
 import {
   validateAttack,
   validatePlayCard,
@@ -61,7 +61,8 @@ function summonMinion(state: GameState, side: PlayerSide, cardId: string): strin
     card: minionCard,
     attack: minionCard.attack,
     health: minionCard.health,
-    attacksRemaining: 1
+    attacksRemaining: 1,
+    divineShield: minionCard.effect === 'divide_shield'
   });
   return instanceId;
 }
@@ -150,5 +151,54 @@ describe('validateAttack', () => {
     const attackerId = summonMinion(state, 'A', CARD_IDS.knight);
 
     expect(() => validateAttack(state, 'A', attackerId, { type: 'hero', side: 'B' })).not.toThrow();
+  });
+});
+
+describe('divide shield effect', () => {
+  it('absorbs the first instance of damage from attacks', () => {
+    const state = createState();
+    const defenderId = summonMinion(state, 'A', CARD_IDS.argentSquare);
+    const attackerId = summonMinion(state, 'B', CARD_IDS.knight);
+
+    applyAttack(state, 'B', attackerId, { type: 'minion', side: 'A', entityId: defenderId });
+
+    const defender = state.board.A.find((entity) => entity.instanceId === defenderId);
+    expect(defender?.health).toBe(getCardDefinition(CARD_IDS.argentSquare).health);
+    expect(defender?.divineShield).toBe(false);
+
+    const attacker = state.board.B.find((entity) => entity.instanceId === attackerId);
+    expect(attacker?.health).toBe(
+      getCardDefinition(CARD_IDS.knight).health - getCardDefinition(CARD_IDS.argentSquare).attack
+    );
+
+    if (attacker) {
+      attacker.attacksRemaining = 1;
+    }
+
+    applyAttack(state, 'B', attackerId, { type: 'minion', side: 'A', entityId: defenderId });
+
+    const defenderAfter = state.board.A.find((entity) => entity.instanceId === defenderId);
+    expect(defenderAfter).toBeUndefined();
+  });
+
+  it('absorbs the first instance of spell damage', () => {
+    const state = createState();
+    const defenderId = summonMinion(state, 'B', CARD_IDS.argentSquare);
+    const firstFireboltId = addCard(state, 'A', CARD_IDS.firebolt);
+    state.players.A.mana = { current: 10, max: 10 };
+
+    applyPlayCard(state, 'A', firstFireboltId, { type: 'minion', side: 'B', entityId: defenderId });
+
+    let defender = state.board.B.find((entity) => entity.instanceId === defenderId);
+    expect(defender?.health).toBe(getCardDefinition(CARD_IDS.argentSquare).health);
+    expect(defender?.divineShield).toBe(false);
+
+    const secondFireboltId = addCard(state, 'A', CARD_IDS.firebolt);
+    state.players.A.mana = { current: 10, max: 10 };
+
+    applyPlayCard(state, 'A', secondFireboltId, { type: 'minion', side: 'B', entityId: defenderId });
+
+    defender = state.board.B.find((entity) => entity.instanceId === defenderId);
+    expect(defender).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- track active divine shield charges on minions and consume them during damage resolution
- render a visual highlight for minions protected by divide_shield on the board
- add reducer tests covering divide shield against attacks and spells

## Testing
- npm run build -w shared
- npm run build -w server
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e16f2649ac8329ab5077a65edc7dd6