### PR TITLE
Refactor card effects system

### DIFF
--- a/client/src/gamepixi/Card.tsx
+++ b/client/src/gamepixi/Card.tsx
@@ -142,8 +142,8 @@ export function Card({
         y={CARD_HEIGHT * 0.04}
         style={{ fill: 0xffffff, fontSize: 24, fontWeight: 'bold' }}
       />
-      {card.card.effect ? (<pixiText
-        text={card.card.effect}
+      {card.card.text ? (<pixiText
+        text={card.card.text}
         x={CARD_WIDTH * 0.25}
         y={CARD_HEIGHT * 0.7}
         style={{ fill: 0x000000, fontSize: CARD_WIDTH * 0.1, fontWeight: 'bold' }}

--- a/client/src/gamepixi/layers/Board.tsx
+++ b/client/src/gamepixi/layers/Board.tsx
@@ -6,6 +6,7 @@ import type {
   TargetDescriptor
 } from '@cardstone/shared/types';
 import { getTargetingPredicate } from '@cardstone/shared/targeting';
+import { actionRequiresTarget, getPrimaryPlayAction } from '@cardstone/shared/effects';
 import type { FederatedPointerEvent } from 'pixi.js';
 import { Assets, Container, DisplayObject, Graphics, Point, Rectangle, Texture } from 'pixi.js';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -390,11 +391,11 @@ export default function Board({
     if (targeting.source.kind === 'minion') {
       return getTargetingPredicate({ kind: 'minion' }, playerSide, state);
     }
-    return getTargetingPredicate(
-      { kind: 'spell', effect: targeting.source.card.card.effect },
-      playerSide,
-      state
-    );
+    const action = getPrimaryPlayAction(targeting.source.card.card);
+    if (!action || !actionRequiresTarget(action)) {
+      return null;
+    }
+    return getTargetingPredicate({ kind: 'spell', action }, playerSide, state);
   }, [playerSide, state, targeting]);
 
   const handleTargetOver = useCallback(

--- a/client/src/gamepixi/layers/Hand.tsx
+++ b/client/src/gamepixi/layers/Hand.tsx
@@ -1,4 +1,5 @@
 import type { CardInHand, CardPlacement } from '@cardstone/shared/types';
+import { actionRequiresTarget, getPrimaryPlayAction } from '@cardstone/shared/effects';
 import type { FederatedPointerEvent } from 'pixi.js';
 import { DisplayObject } from 'pixi.js';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -44,7 +45,11 @@ interface CardAnimationState {
 }
 
 function isTargetedSpell(card: CardInHand): boolean {
-  return card.card.type === 'Spell' && (card.card.effect === 'Firebolt' || card.card.effect === 'Heal');
+  if (card.card.type !== 'Spell') {
+    return false;
+  }
+  const action = getPrimaryPlayAction(card.card);
+  return Boolean(action && actionRequiresTarget(action));
 }
 
 function cloneTransform(transform: Transform): Transform {

--- a/shared/cards/demo.ts
+++ b/shared/cards/demo.ts
@@ -1,6 +1,5 @@
 import type { CardDefinition, MinionCard, SpellCard } from '../types.js';
 import { CARD_IDS } from '../constants.js';
-
 const minions: Record<string, MinionCard> = {
   [CARD_IDS.argentSquare]: {
     id: CARD_IDS.argentSquare,
@@ -9,7 +8,12 @@ const minions: Record<string, MinionCard> = {
     cost: 1,
     attack: 1,
     health: 1,
-    effect: 'divide_shield'
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'DivineShield' }
+      }
+    ]
   },
   [CARD_IDS.berserk]: {
     id: CARD_IDS.berserk,
@@ -18,10 +22,12 @@ const minions: Record<string, MinionCard> = {
     cost: 2,
     attack: 2,
     health: 3,
-    effect: 'berserk',
-    effectProperty: {
-      attack: 2
-    }
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Berserk', data: { attack: 2 } }
+      }
+    ]
   },
   [CARD_IDS.bullguard]: {
     id: CARD_IDS.bullguard,
@@ -30,7 +36,12 @@ const minions: Record<string, MinionCard> = {
     cost: 1,
     attack: 0,
     health: 4,
-    effect: 'taunt'
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Taunt' }
+      }
+    ]
   },
   [CARD_IDS.cunningPeople]: {
     id: CARD_IDS.cunningPeople,
@@ -47,7 +58,12 @@ const minions: Record<string, MinionCard> = {
     cost: 2,
     attack: 2,
     health: 2,
-    effect: 'battlecry',
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Custom', key: 'Battlecry' }
+      }
+    ],
   },
   [CARD_IDS.draugr]: {
     id: CARD_IDS.draugr,
@@ -56,7 +72,12 @@ const minions: Record<string, MinionCard> = {
     cost: 2,
     attack: 3,
     health: 2,
-    effect: 'deathrattle'
+    effects: [
+      {
+        trigger: { type: 'Deathrattle' },
+        action: { type: 'Custom', key: 'Deathrattle' }
+      }
+    ]
   },
   [CARD_IDS.elunaPrist]: {
     id: CARD_IDS.elunaPrist,
@@ -73,7 +94,12 @@ const minions: Record<string, MinionCard> = {
     cost: 1,
     attack: 1,
     health: 3,
-    effect: 'battlecry'
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Custom', key: 'Battlecry' }
+      }
+    ]
   },
   [CARD_IDS.fireBeard]: {
     id: CARD_IDS.fireBeard,
@@ -82,7 +108,12 @@ const minions: Record<string, MinionCard> = {
     cost: 3,
     attack: 2,
     health: 3,
-    effect: 'berserk'
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Berserk' }
+      }
+    ]
   },
   [CARD_IDS.forestDweller]: {
     id: CARD_IDS.forestDweller,
@@ -91,7 +122,12 @@ const minions: Record<string, MinionCard> = {
     cost: 2,
     attack: 2,
     health: 4,
-    effect: 'taunt'
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Taunt' }
+      }
+    ]
   },
   [CARD_IDS.frongProtector]: {
     id: CARD_IDS.frongProtector,
@@ -100,7 +136,12 @@ const minions: Record<string, MinionCard> = {
     cost: 3,
     attack: 3,
     health: 5,
-    effect: 'taunt'
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Taunt' }
+      }
+    ]
   },
   [CARD_IDS.gatplank]: {
     id: CARD_IDS.gatplank,
@@ -109,7 +150,12 @@ const minions: Record<string, MinionCard> = {
     cost: 4,
     attack: 5,
     health: 3,
-    effect: 'battlecry'
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Custom', key: 'Battlecry' }
+      }
+    ]
   },
   [CARD_IDS.germesProtector]: {
     id: CARD_IDS.germesProtector,
@@ -118,7 +164,12 @@ const minions: Record<string, MinionCard> = {
     cost: 3,
     attack: 2,
     health: 6,
-    effect: 'taunt'
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Taunt' }
+      }
+    ]
   },
   [CARD_IDS.hoarder]: {
     id: CARD_IDS.hoarder,
@@ -127,7 +178,12 @@ const minions: Record<string, MinionCard> = {
     cost: 2,
     attack: 2,
     health: 1,
-    effect: 'take_card'
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'DrawCard', amount: 1 }
+      }
+    ]
   },
   [CARD_IDS.knight]: {
     id: CARD_IDS.knight,
@@ -144,7 +200,12 @@ const minions: Record<string, MinionCard> = {
     cost: 1,
     attack: 2,
     health: 1,
-    effect: 'deathrattle'
+    effects: [
+      {
+        trigger: { type: 'Deathrattle' },
+        action: { type: 'Custom', key: 'Deathrattle' }
+      }
+    ]
   },
   [CARD_IDS.miniDragon]: {
     id: CARD_IDS.miniDragon,
@@ -161,7 +222,12 @@ const minions: Record<string, MinionCard> = {
     cost: 2,
     attack: 2,
     health: 3,
-    effect: 'battlecry'
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Custom', key: 'Battlecry' }
+      }
+    ]
   },
   [CARD_IDS.ninja]: {
     id: CARD_IDS.ninja,
@@ -170,7 +236,12 @@ const minions: Record<string, MinionCard> = {
     cost: 3,
     attack: 3,
     health: 2,
-    effect: 'steals'
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Steals' }
+      }
+    ]
   },
   [CARD_IDS.python]: {
     id: CARD_IDS.python,
@@ -179,7 +250,12 @@ const minions: Record<string, MinionCard> = {
     cost: 4,
     attack: 4,
     health: 4,
-    effect: 'steals'
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Steals' }
+      }
+    ]
   },
   [CARD_IDS.raider]: {
     id: CARD_IDS.raider,
@@ -196,7 +272,12 @@ const minions: Record<string, MinionCard> = {
     cost: 3,
     attack: 2,
     health: 4,
-    effect: 'divide_shield'
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'DivineShield' }
+      }
+    ]
   },
   [CARD_IDS.sage]: {
     id: CARD_IDS.sage,
@@ -205,7 +286,12 @@ const minions: Record<string, MinionCard> = {
     cost: 4,
     attack: 2,
     health: 5,
-    effect: 'take_card'
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'DrawCard', amount: 1 }
+      }
+    ]
   },
   [CARD_IDS.sergeant]: {
     id: CARD_IDS.sergeant,
@@ -222,7 +308,12 @@ const minions: Record<string, MinionCard> = {
     cost: 4,
     attack: 3,
     health: 6,
-    effect: 'taunt'
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Taunt' }
+      }
+    ]
   },
   [CARD_IDS.skeleton]: {
     id: CARD_IDS.skeleton,
@@ -231,7 +322,12 @@ const minions: Record<string, MinionCard> = {
     cost: 1,
     attack: 2,
     health: 1,
-    effect: 'deathrattle'
+    effects: [
+      {
+        trigger: { type: 'Deathrattle' },
+        action: { type: 'Custom', key: 'Deathrattle' }
+      }
+    ]
   },
   [CARD_IDS.surtur]: {
     id: CARD_IDS.surtur,
@@ -240,7 +336,12 @@ const minions: Record<string, MinionCard> = {
     cost: 7,
     attack: 7,
     health: 7,
-    effect: 'berserk'
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Berserk' }
+      }
+    ]
   },
   [CARD_IDS.tiger]: {
     id: CARD_IDS.tiger,
@@ -249,7 +350,12 @@ const minions: Record<string, MinionCard> = {
     cost: 6,
     attack: 6,
     health: 5,
-    effect: 'steals'
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Steals' }
+      }
+    ]
   },
   [CARD_IDS.vikingGirl]: {
     id: CARD_IDS.vikingGirl,
@@ -258,7 +364,12 @@ const minions: Record<string, MinionCard> = {
     cost: 3,
     attack: 3,
     health: 4,
-    effect: 'battlecry'
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Custom', key: 'Battlecry' }
+      }
+    ]
   },
   [CARD_IDS.warrior]: {
     id: CARD_IDS.warrior,
@@ -267,7 +378,12 @@ const minions: Record<string, MinionCard> = {
     cost: 6,
     attack: 6,
     health: 7,
-    effect: 'taunt'
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Taunt' }
+      }
+    ]
   },
   [CARD_IDS.waterElemental]: {
     id: CARD_IDS.waterElemental,
@@ -276,7 +392,12 @@ const minions: Record<string, MinionCard> = {
     cost: 5,
     attack: 4,
     health: 6,
-    effect: 'battlecry'
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Custom', key: 'Battlecry' }
+      }
+    ]
   },
   [CARD_IDS.wisp]: {
     id: CARD_IDS.wisp,
@@ -303,42 +424,52 @@ const minions: Record<string, MinionCard> = {
     health: 5
   }
 };
-
 const spells: Record<string, SpellCard> = {
   [CARD_IDS.firebolt]: {
     id: CARD_IDS.firebolt,
     name: 'Firebolt',
     type: 'Spell',
     cost: 2,
-    effect: 'Firebolt',
-    amount: 2
+    text: 'Deal 2 damage.',
+    effects: [
+      {
+        trigger: { type: 'Play' },
+        action: { type: 'Damage', amount: 2, target: 'AllEnemies' }
+      }
+    ]
   },
   [CARD_IDS.heal]: {
     id: CARD_IDS.heal,
     name: 'Mending Touch',
     type: 'Spell',
     cost: 2,
-    effect: 'Heal',
-    amount: 2
+    text: 'Restore 2 Health.',
+    effects: [
+      {
+        trigger: { type: 'Play' },
+        action: { type: 'Heal', amount: 2, target: 'AllFriendlies' }
+      }
+    ]
   },
   [CARD_IDS.coin]: {
     id: CARD_IDS.coin,
     name: 'The Coin',
     type: 'Spell',
     cost: 0,
-    effect: 'Coin',
-    amount: 1
+    text: 'Gain 1 temporary mana crystal.',
+    effects: [
+      {
+        trigger: { type: 'Play' },
+        action: { type: 'ManaCrystal', amount: 1 }
+      }
+    ]
   }
 };
-
-
 export const DEMO_CARDS: Record<string, CardDefinition> = {
   ...minions,
   ...spells
 };
-
 export const DEMO_CARD_POOL = Object.values(DEMO_CARDS);
-
 export function getCardDefinition(cardId: string): CardDefinition {
   const card = DEMO_CARDS[cardId];
   if (!card) {

--- a/shared/effects.ts
+++ b/shared/effects.ts
@@ -1,0 +1,81 @@
+import type {
+  CardDefinition,
+  Effect,
+  EffectAction,
+  EffectTrigger,
+  SpellCard,
+  TargetSelector
+} from './types.js';
+
+export type EffectTriggerType = EffectTrigger['type'];
+
+export function getCardEffects(card: CardDefinition): Effect[] {
+  return card.effects ?? [];
+}
+
+export function getEffectsByTrigger(
+  card: CardDefinition,
+  triggerType: EffectTriggerType
+): Effect[] {
+  return getCardEffects(card).filter((effect) => effect.trigger.type === triggerType);
+}
+
+export function getFirstActionByTrigger(
+  card: CardDefinition,
+  triggerType: EffectTriggerType
+): EffectAction | undefined {
+  const effect = getEffectsByTrigger(card, triggerType)[0];
+  return effect?.action;
+}
+
+export function getPrimaryPlayAction(card: SpellCard): EffectAction | undefined {
+  return getFirstActionByTrigger(card, 'Play');
+}
+
+export function hasCustomEffect(card: CardDefinition, key: string): boolean {
+  return getCardEffects(card).some(
+    (effect) => effect.action.type === 'Custom' && effect.action.key === key
+  );
+}
+
+export function hasTaunt(card: CardDefinition): boolean {
+  return getCardEffects(card).some(
+    (effect) => effect.trigger.type === 'Aura' && effect.action.type === 'Custom' && effect.action.key === 'Taunt'
+  );
+}
+
+export function hasDivineShield(card: CardDefinition): boolean {
+  return getCardEffects(card).some(
+    (effect) =>
+      effect.trigger.type === 'Aura' && effect.action.type === 'Custom' && effect.action.key === 'DivineShield'
+  );
+}
+
+export function actionRequiresTarget(action: EffectAction): boolean {
+  switch (action.type) {
+    case 'Damage':
+    case 'Heal':
+      return true;
+    case 'Buff':
+      return action.target !== 'Self';
+    case 'Summon':
+      return false;
+    case 'DrawCard':
+    case 'ManaCrystal':
+    case 'Custom':
+      return false;
+    default:
+      throw new Error('Unhandled effect action type');
+  }
+}
+
+export function getActionTargetSelector(action: EffectAction): TargetSelector | undefined {
+  switch (action.type) {
+    case 'Damage':
+    case 'Heal':
+    case 'Buff':
+      return action.target;
+    default:
+      return undefined;
+  }
+}

--- a/shared/package.json
+++ b/shared/package.json
@@ -11,6 +11,8 @@
     "./types.js": "./dist/types.js",
     "./constants": "./dist/constants.js",
     "./constants.js": "./dist/constants.js",
+    "./effects": "./dist/effects.js",
+    "./effects.js": "./dist/effects.js",
     "./cards/*": "./dist/cards/*.js",
     "./cards/*.js": "./dist/cards/*.js"
   },

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -4,36 +4,84 @@ export type Phase = 'Start' | 'Main' | 'End';
 export type EntityId = string;
 export type CardId = string;
 
-export type CardType = 'Minion' | 'Spell';
+export type TargetSelector =
+  | 'Self'
+  | 'FriendlyMinion'
+  | 'EnemyMinion'
+  | 'AnyMinion'
+  | 'Hero'
+  | 'AllEnemies'
+  | 'AllFriendlies'
+  | 'RandomEnemy';
+
+export type EffectTrigger =
+  | { type: 'Battlecry' }
+  | { type: 'Deathrattle' }
+  | { type: 'SpellCast' }
+  | { type: 'TurnStart' }
+  | { type: 'TurnEnd' }
+  | { type: 'Attack' }
+  | { type: 'Play' }
+  | { type: 'Aura' };
+
+export type EffectAction =
+  | { type: 'Damage'; amount: number; target: TargetSelector }
+  | { type: 'Heal'; amount: number; target: TargetSelector }
+  | { type: 'DrawCard'; amount: number }
+  | { type: 'Summon'; cardId: string; count: number; target: 'Board' }
+  | { type: 'Buff'; stats: { attack?: number; health?: number }; target: TargetSelector }
+  | { type: 'ManaCrystal'; amount: number }
+  | { type: 'Custom'; key: string; data?: unknown };
+
+export type EffectCondition =
+  | { type: 'IfDamaged'; target: TargetSelector }
+  | { type: 'IfClass'; class: string }
+  | { type: 'RandomChance'; percent: number }
+  | { type: 'HasTribe'; tribe: string };
+
+export type Effect = {
+  trigger: EffectTrigger;
+  action: EffectAction;
+  condition?: EffectCondition;
+};
+
+export type CardType = 'Minion' | 'Spell' | 'Weapon' | 'Hero';
 
 export type CardPlacement = 'left' | 'right';
 
-export interface CardBase {
+interface CardDefinitionBase {
   id: CardId;
   name: string;
-  cost: number;
   type: CardType;
+  cost: number;
+  rarity?: 'Common' | 'Rare' | 'Epic' | 'Legendary';
+  set?: string;
+  tribe?: string;
+  text?: string;
+  effects?: Effect[];
 }
 
-export interface MinionCard extends CardBase {
+export type MinionCard = CardDefinitionBase & {
   type: 'Minion';
   attack: number;
   health: number;
-  text?: string;
-  effect?: string;
-  effectProperty?: Record<string, number>
+};
 
-}
-
-export type SpellEffect = 'Firebolt' | 'Heal' | 'Coin';
-
-export interface SpellCard extends CardBase {
+export type SpellCard = CardDefinitionBase & {
   type: 'Spell';
-  effect: SpellEffect;
-  amount?: number;
-}
+};
 
-export type CardDefinition = MinionCard | SpellCard;
+export type WeaponCard = CardDefinitionBase & {
+  type: 'Weapon';
+  attack: number;
+  durability: number;
+};
+
+export type HeroCard = CardDefinitionBase & {
+  type: 'Hero';
+};
+
+export type CardDefinition = MinionCard | SpellCard | WeaponCard | HeroCard;
 
 export interface CardInHand {
   instanceId: EntityId;

--- a/tests/match.reducer.test.ts
+++ b/tests/match.reducer.test.ts
@@ -8,6 +8,7 @@ import {
   validatePlayCard,
   ValidationError
 } from '@cardstone/server/match/validate.js';
+import { hasDivineShield } from '@cardstone/shared/effects.js';
 
 
 function createState(): GameState {
@@ -62,7 +63,7 @@ function summonMinion(state: GameState, side: PlayerSide, cardId: string): strin
     attack: minionCard.attack,
     health: minionCard.health,
     attacksRemaining: 1,
-    divineShield: minionCard.effect === 'divide_shield'
+    divineShield: hasDivineShield(minionCard)
   });
   return instanceId;
 }


### PR DESCRIPTION
## Summary
- replace legacy effect fields with structured effect definitions and shared helpers
- update card data, targeting utilities, and server reducer/validation to act on effect actions
- adjust client UI and tests to consume the new effect metadata

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e1722035bc832998fa0b9fb14da40b