### PR TITLE
Prevent duplicate attack animations after local strike

### DIFF
--- a/client/src/gamepixi/layers/Board.tsx
+++ b/client/src/gamepixi/layers/Board.tsx
@@ -324,6 +324,8 @@ export default function Board({
           target.type === 'hero'
             ? { type: 'hero', side: target.side }
             : { type: 'minion', side: target.side, entityId: target.entityId };
+        // Kick off the local strike animation immediately so the attacker
+        // lunges before the server confirms the combat result.
         enqueueLocalAttackAnimation({
           attackerId: action.source.entityId,
           side: playerSide,

--- a/client/src/gamepixi/layers/Effects.tsx
+++ b/client/src/gamepixi/layers/Effects.tsx
@@ -50,6 +50,8 @@ export default function Effects({ state, playerSide, width, height }: EffectsPro
   const consumeLocalAttackQueue = useUiStore((s) => s.consumeLocalAttackQueue);
   const localAttackQueueVersion = useUiStore((s) => s.localAttackQueueVersion);
 
+  const pendingLocalAttackersRef = useRef(new Map<string, number>());
+
   const layout = useMemo(
     () => computeBoardLayout(state, playerSide, width, height),
     [state, playerSide, width, height]
@@ -65,6 +67,7 @@ export default function Effects({ state, playerSide, width, height }: EffectsPro
       setAnimations([]);
       prevStateRef.current = null;
       prevLayoutRef.current = null;
+      pendingLocalAttackersRef.current.clear();
     };
   }, [resetMinionAnimations]);
 
@@ -84,14 +87,28 @@ export default function Effects({ state, playerSide, width, height }: EffectsPro
       return;
     }
 
+    const pendingLocalAttackers = pendingLocalAttackersRef.current;
     const attackEvents = detectAttackEvents(previous, state);
-    if (attackEvents.length === 0) {
+    const filteredEvents = attackEvents.filter((event) => {
+      const pending = pendingLocalAttackers.get(event.attackerId);
+      if (pending && pending > 0) {
+        if (pending === 1) {
+          pendingLocalAttackers.delete(event.attackerId);
+        } else {
+          pendingLocalAttackers.set(event.attackerId, pending - 1);
+        }
+        return false;
+      }
+      return true;
+    });
+
+    if (filteredEvents.length === 0) {
       prevStateRef.current = state;
       prevLayoutRef.current = layout;
       return;
     }
 
-    const busyAttackers = new Set(attackEvents.map((event) => event.attackerId));
+    const busyAttackers = new Set(filteredEvents.map((event) => event.attackerId));
 
     setAnimations((current) => {
       const survivors: AttackAnimation[] = [];
@@ -101,7 +118,7 @@ export default function Effects({ state, playerSide, width, height }: EffectsPro
         }
       });
 
-      attackEvents.forEach((event, index) => {
+      filteredEvents.forEach((event, index) => {
         const origin =
           layout.minions[event.side]?.[event.attackerId] ??
           previousLayout?.minions[event.side]?.[event.attackerId];
@@ -141,6 +158,13 @@ export default function Effects({ state, playerSide, width, height }: EffectsPro
       return;
     }
     const previousLayout = prevLayoutRef.current;
+    // Record that these attackers are already animating locally so that
+    // the upcoming authoritative server update does not schedule a
+    // duplicate strike animation for the same attacker.
+    localEvents.forEach((event) => {
+      const pending = pendingLocalAttackersRef.current.get(event.attackerId) ?? 0;
+      pendingLocalAttackersRef.current.set(event.attackerId, pending + 1);
+    });
     setAnimations((current) => {
       const survivors: AttackAnimation[] = [];
       const busyAttackers = new Set(localEvents.map((event) => event.attackerId));


### PR DESCRIPTION
## Summary
- track pending local minion strikes in the effects layer to prevent server updates from replaying the same animation
- leave a note in the board pointer handler describing why the local animation is queued immediately

## Testing
- npm run lint -w client *(fails: existing lint warnings in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68e2cea00f288329830ddf0d89f191ea