### PR TITLE
Enhance targeting arrow visuals

### DIFF
--- a/client/src/gamepixi/effects/TargetingArrow.tsx
+++ b/client/src/gamepixi/effects/TargetingArrow.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
+import type { PlayerSide } from '@cardstone/shared/types';
 import { useUiStore } from '../../state/store';
 import useMiniTicker from '../hooks/useMiniTicker';
 import type { Graphics } from 'pixi.js';
@@ -11,6 +12,52 @@ const TIP_WIDTH = 12;
 const TIP_LENGTH = 46;
 const TIP_SCALE = 1.5;
 const NORMALIZE_EPSILON = 1e-4;
+
+type ArrowThemeKey = 'ally' | 'enemy' | 'neutral';
+
+interface ArrowTheme {
+  glow: number;
+  bodyFill: number;
+  bodyOutline: number;
+  coreLine: number;
+  headFill: number;
+  headOutline: number;
+  tailFill: number;
+  spark: number;
+}
+
+const ARROW_THEMES: Record<ArrowThemeKey, ArrowTheme> = {
+  ally: {
+    glow: 0x8fdcff,
+    bodyFill: 0x1f5fa8,
+    bodyOutline: 0xbfe9ff,
+    coreLine: 0xffffff,
+    headFill: 0x17477c,
+    headOutline: 0xe3f6ff,
+    tailFill: 0x0e2f52,
+    spark: 0xb3ecff
+  },
+  enemy: {
+    glow: 0xff7d73,
+    bodyFill: 0x9f1e14,
+    bodyOutline: 0xffc1b0,
+    coreLine: 0xffffff,
+    headFill: 0x76160f,
+    headOutline: 0xffe3d9,
+    tailFill: 0x4e0d0a,
+    spark: 0xffd0c6
+  },
+  neutral: {
+    glow: 0xffd86b,
+    bodyFill: 0x8a6414,
+    bodyOutline: 0xfff0c7,
+    coreLine: 0xffffff,
+    headFill: 0x6d4d0e,
+    headOutline: 0xfff8dd,
+    tailFill: 0x4b3309,
+    spark: 0xfff6d3
+  }
+};
 
 interface Vec2 {
   x: number;
@@ -106,7 +153,11 @@ function useSmoothedPoint(target: Vec2 | null, stiffness = 18) {
   return point;
 }
 
-export default function TargetingArrow() {
+interface TargetingArrowProps {
+  playerSide: PlayerSide;
+}
+
+export default function TargetingArrow({ playerSide }: TargetingArrowProps) {
   // Когда игрок зажимает существо на доске, слой Board записывает в zustand-store структуру
   // TargetingState: точку старта (центр существа), id указателя и текущие координаты курсора.
   // Пока эта запись существует, Board обновляет поле `current` в onPointerMove, а этот эффект
@@ -114,6 +165,7 @@ export default function TargetingArrow() {
   // Board сбрасывает TargetingState (на отпускании кнопки или отмене), компонент перестает
   // рендериться — именно так появляется и исчезает «стрелочка» наведения атаки.
   const targeting = useUiStore((state) => state.targeting);
+  const currentTarget = useUiStore((state) => state.currentTarget ?? null);
   const smoothedCurrent = useSmoothedPoint(targeting ? targeting.current : null);
   const cacheRef = useRef<CurveCache>();
   const lastCurveRef = useRef<CurveGeometry | null>(null);
@@ -145,6 +197,60 @@ export default function TargetingArrow() {
 
   const tipRotation = Math.atan2(tipDirection.y, tipDirection.x);
 
+  const [pulsePhase, setPulsePhase] = useState(0);
+  useMiniTicker(
+    (deltaMS) => {
+      setPulsePhase((prev) => {
+        const next = prev + deltaMS * 0.006;
+        return next > Math.PI * 2 ? next - Math.PI * 2 : next;
+      });
+    },
+    hasTarget
+  );
+
+  const pulseAlpha = 0.78 + 0.22 * Math.sin(pulsePhase);
+  const sparkAlpha = 0.55 + 0.45 * Math.sin(pulsePhase * 1.5 + Math.PI / 3);
+
+  const themeKey: ArrowThemeKey = currentTarget
+    ? currentTarget.side === playerSide
+      ? 'ally'
+      : 'enemy'
+    : 'neutral';
+  const theme = ARROW_THEMES[themeKey];
+
+  const drawGlow = (graphics: Graphics) => {
+    graphics.clear();
+    const leftOutline: Vec2[] = [];
+    const rightOutline: Vec2[] = [];
+    for (let i = 0; i < SAMPLE_COUNT; i += 1) {
+      const px = positions[i * 2];
+      const py = positions[i * 2 + 1];
+      const tx = tangents[i * 2];
+      const ty = tangents[i * 2 + 1];
+      const tangentLength = Math.hypot(tx, ty) || 1;
+      const nx = -ty / tangentLength;
+      const ny = tx / tangentLength;
+      const t = i / (SAMPLE_COUNT - 1);
+      const width =
+        BASE_BODY_WIDTH * 1.35 * (1 - t * 0.5) +
+        (TIP_WIDTH * 1.35 + 14) * t;
+      const halfWidth = width * 0.5;
+      leftOutline.push({ x: px + nx * halfWidth, y: py + ny * halfWidth });
+      rightOutline.push({ x: px - nx * halfWidth, y: py - ny * halfWidth });
+    }
+
+    graphics.beginFill(theme.glow, 0.28 + 0.25 * pulseAlpha);
+    graphics.moveTo(leftOutline[0].x, leftOutline[0].y);
+    for (let i = 1; i < leftOutline.length; i += 1) {
+      graphics.lineTo(leftOutline[i].x, leftOutline[i].y);
+    }
+    for (let i = rightOutline.length - 1; i >= 0; i -= 1) {
+      graphics.lineTo(rightOutline[i].x, rightOutline[i].y);
+    }
+    graphics.closePath();
+    graphics.endFill();
+  };
+
   const drawBody = (graphics: Graphics) => {
     graphics.clear();
     const leftOutline: Vec2[] = [];
@@ -160,15 +266,14 @@ export default function TargetingArrow() {
       const t = i / (SAMPLE_COUNT - 1);
       const width =
         BASE_BODY_WIDTH * (1 - t * 0.55) +
-        (TIP_WIDTH + 4) * t;
+        (TIP_WIDTH + 6) * t;
       const halfWidth = width * 0.5;
       leftOutline.push({ x: px + nx * halfWidth, y: py + ny * halfWidth });
       rightOutline.push({ x: px - nx * halfWidth, y: py - ny * halfWidth });
     }
 
-    // The fill-first, stroke-second order matches how Hearthstone's VFX keeps the center glowing.
-    graphics.lineStyle(3, 0xffffff, 1);
-    graphics.beginFill(0xd63031, 1);
+    graphics.lineStyle(4, theme.bodyOutline, 0.95);
+    graphics.beginFill(theme.bodyFill, 0.95);
     graphics.moveTo(leftOutline[0].x, leftOutline[0].y);
     for (let i = 1; i < leftOutline.length; i += 1) {
       graphics.lineTo(leftOutline[i].x, leftOutline[i].y);
@@ -179,7 +284,7 @@ export default function TargetingArrow() {
     graphics.closePath();
     graphics.endFill();
 
-    graphics.lineStyle(2, 0xff7675, 1);
+    graphics.lineStyle(2.4, theme.coreLine, 0.82);
     graphics.moveTo(positions[0], positions[1]);
     for (let i = 1; i < SAMPLE_COUNT; i += 1) {
       graphics.lineTo(positions[i * 2], positions[i * 2 + 1]);
@@ -188,16 +293,48 @@ export default function TargetingArrow() {
 
   const drawHead = (graphics: Graphics) => {
     graphics.clear();
-    graphics.lineStyle(2, 0xffffff, 1);
-    graphics.beginFill(0xc0392b, 1);
+    const base = -TIP_LENGTH * TIP_SCALE;
+    const wing = TIP_WIDTH * TIP_SCALE * 0.8;
+
+    graphics.lineStyle(3, theme.headOutline, 0.95);
+    graphics.beginFill(theme.headFill, 1);
     graphics.moveTo(0, 0);
-    graphics.lineTo(-TIP_LENGTH * TIP_SCALE, TIP_WIDTH * TIP_SCALE * 0.9);
-    graphics.quadraticCurveTo(
-      (-TIP_LENGTH * 0.5) * TIP_SCALE,
-      0,
-      -TIP_LENGTH * TIP_SCALE,
-      -TIP_WIDTH * TIP_SCALE * 0.9
-    );
+    graphics.lineTo(base * 0.55, wing);
+    graphics.lineTo(base, 0);
+    graphics.lineTo(base * 0.55, -wing);
+    graphics.closePath();
+    graphics.endFill();
+
+    const tailHeight = TIP_WIDTH * TIP_SCALE * 0.6;
+    graphics.beginFill(theme.tailFill, 0.94);
+    graphics.drawRoundedRect(base - 14, -tailHeight / 2, 16, tailHeight, 4);
+    graphics.endFill();
+
+    graphics.lineStyle(2.8, theme.spark, sparkAlpha);
+    const sparkLength = TIP_LENGTH * 0.45;
+    graphics.moveTo(base * 0.5, 0);
+    graphics.lineTo(base * 0.5 - sparkLength, tailHeight * 0.5);
+    graphics.moveTo(base * 0.5, 0);
+    graphics.lineTo(base * 0.5 - sparkLength, -tailHeight * 0.5);
+    graphics.moveTo(base * 0.8, 0);
+    graphics.lineTo(base * 0.8 - sparkLength * 0.6, tailHeight * 0.9);
+    graphics.moveTo(base * 0.8, 0);
+    graphics.lineTo(base * 0.8 - sparkLength * 0.6, -tailHeight * 0.9);
+
+    graphics.lineStyle(2, theme.coreLine, 0.85);
+    graphics.moveTo(base, 0);
+    graphics.lineTo(base - 12, 0);
+  };
+
+  const drawHeadGlow = (graphics: Graphics) => {
+    graphics.clear();
+    const base = -TIP_LENGTH * TIP_SCALE;
+    const wing = TIP_WIDTH * TIP_SCALE * 1.05;
+    graphics.beginFill(theme.glow, 0.38 + 0.32 * pulseAlpha);
+    graphics.moveTo(6, 0);
+    graphics.lineTo(base * 0.6, wing);
+    graphics.lineTo(base - 6, 0);
+    graphics.lineTo(base * 0.6, -wing);
     graphics.closePath();
     graphics.endFill();
   };
@@ -208,8 +345,10 @@ export default function TargetingArrow() {
 
   return (
     <pixiContainer eventMode="none">
+      <pixiGraphics draw={drawGlow} alpha={pulseAlpha} blendMode="add" />
       <pixiGraphics draw={drawBody} />
       <pixiContainer x={tipPosition.x} y={tipPosition.y} rotation={tipRotation} eventMode="none">
+        <pixiGraphics draw={drawHeadGlow} alpha={pulseAlpha} blendMode="add" />
         <pixiGraphics draw={drawHead} />
       </pixiContainer>
     </pixiContainer>

--- a/client/src/gamepixi/layers/Effects.tsx
+++ b/client/src/gamepixi/layers/Effects.tsx
@@ -374,7 +374,7 @@ export default function Effects({ state, playerSide, width, height }: EffectsPro
 
   return (
     <pixiContainer>
-      <TargetingArrow />
+      <TargetingArrow playerSide={playerSide} />
       <pixiText
         text={`Mana ${player.mana.current}/${player.mana.max}`}
         x={width - 220}


### PR DESCRIPTION
## Summary
- add themed color palettes, glow, and pulsing effects to the targeting arrow
- render a stylized arrowhead with sparks and a halo for Blizzard-like feedback
- pass the local player side so the arrow can swap between ally, enemy, and neutral palettes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e53e9ecc1083299ac51b5b35c081d3