### PR TITLE
Show friendly minion highlight only when they can attack

### DIFF
--- a/client/src/gamepixi/layers/Board.tsx
+++ b/client/src/gamepixi/layers/Board.tsx
@@ -485,14 +485,6 @@ export default function Board({
 
         const reticleColor = side === playerSide ? 0x55efc4 : 0xff7675;
 
-        const fillColor = isFriendly
-          ? canAttackThisMinion
-            ? 0x78ff5a
-            : 0x0984e3
-          : isTargeted
-            ? 0xff7675
-            : 0xd63031;
-
         const handleDown =
           interactive && isFriendly
             ? (event: FederatedPointerEvent) => handleStartAttack(entity, event)
@@ -544,24 +536,25 @@ export default function Board({
                 : undefined
             }
           >
-            <pixiGraphics
+            {isFriendly && canAttackThisMinion ? (
+              <pixiGraphics
                 blendMode={"add"}
                 anchor={0.5}
                 alpha={0.7}
                 filters={[blurFilter]}
-              draw={(g) => {
-                g.clear();
-                  g.beginFill(fillColor,  isFriendly && !canAttackThisMinion ? 0.6 : 0.85); // зелёный
+                draw={(g) => {
+                  g.clear();
+                  g.beginFill(0x78ff5a, 0.85);
                   g.drawEllipse(
-                      MINION_WIDTH / 2,
-                      MINION_HEIGHT / 2,
-                      MINION_WIDTH / 2 + 8,
-                      MINION_HEIGHT / 2 + 8
+                    MINION_WIDTH / 2,
+                    MINION_HEIGHT / 2,
+                    MINION_WIDTH / 2 + 8,
+                    MINION_HEIGHT / 2 + 8
                   );
-                  // g.drawCircle(0, 0, 50);   // радиус ореола
                   g.endFill();
-              }}
-            />
+                }}
+              />
+            ) : null}
             {entity.divineShield ? (
               <pixiGraphics
                 draw={(g) => {


### PR DESCRIPTION
## Summary
- render the friendly minion glow only when the minion can attack, keeping the existing green color
- remove highlight overlays for non-attackable and enemy minions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e53ed4aba4832998ea8f4b3c569a3b