### PR TITLE
Add demo card definitions for asset images and update default deck

### DIFF
--- a/shared/cards/demo.ts
+++ b/shared/cards/demo.ts
@@ -424,6 +424,391 @@ const minions: Record<string, MinionCard> = {
     health: 5
   },
 
+  [CARD_IDS.abomination]: {
+    id: CARD_IDS.abomination,
+    name: 'Abomination',
+    type: 'Minion',
+    cost: 6,
+    attack: 4,
+    health: 7,
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Taunt' }
+      },
+      {
+        trigger: { type: 'Deathrattle' },
+        action: { type: 'Custom', key: 'DamageAllMinions', data: { amount: 2 } }
+      }
+    ]
+  },
+  [CARD_IDS.alchimist]: {
+    id: CARD_IDS.alchimist,
+    name: 'Alchimist',
+    type: 'Minion',
+    cost: 2,
+    attack: 2,
+    health: 3,
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Custom', key: 'SwapAtkHealth', data: { target: 'AnyMinion' } }
+      }
+    ]
+  },
+  [CARD_IDS.bartender]: {
+    id: CARD_IDS.bartender,
+    name: 'Bartender',
+    type: 'Minion',
+    cost: 3,
+    attack: 3,
+    health: 4,
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Heal', amount: 3, target: 'Hero' }
+      }
+    ]
+  },
+  [CARD_IDS.brainEaterZombi]: {
+    id: CARD_IDS.brainEaterZombi,
+    name: 'Brain Eater Zombi',
+    type: 'Minion',
+    cost: 3,
+    attack: 3,
+    health: 3,
+    effects: [
+      {
+        trigger: { type: 'Deathrattle' },
+        action: { type: 'Heal', amount: 3, target: 'Hero' }
+      }
+    ]
+  },
+  [CARD_IDS.bubusDog]: {
+    id: CARD_IDS.bubusDog,
+    name: "Bubu's Dog",
+    type: 'Minion',
+    cost: 1,
+    attack: 1,
+    health: 2,
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Charge' }
+      }
+    ]
+  },
+  [CARD_IDS.draeneiWarrior]: {
+    id: CARD_IDS.draeneiWarrior,
+    name: 'Draenei Warrior',
+    type: 'Minion',
+    cost: 4,
+    attack: 4,
+    health: 5,
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Taunt' }
+      }
+    ]
+  },
+  [CARD_IDS.dwarfBlacksmith]: {
+    id: CARD_IDS.dwarfBlacksmith,
+    name: 'Dwarf Blacksmith',
+    type: 'Minion',
+    cost: 4,
+    attack: 4,
+    health: 4,
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Custom', key: 'Battlecry' }
+      }
+    ]
+  },
+  [CARD_IDS.elfFireMage]: {
+    id: CARD_IDS.elfFireMage,
+    name: 'Elf Fire Mage',
+    type: 'Minion',
+    cost: 4,
+    attack: 4,
+    health: 3,
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Damage', amount: 2, target: 'AnyMinion' }
+      }
+    ]
+  },
+  [CARD_IDS.frostSpirit]: {
+    id: CARD_IDS.frostSpirit,
+    name: 'Frost Spirit',
+    type: 'Minion',
+    cost: 3,
+    attack: 2,
+    health: 4,
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Custom', key: 'Freeze', data: { target: 'AnyMinion' } }
+      }
+    ]
+  },
+  [CARD_IDS.gnomeMage]: {
+    id: CARD_IDS.gnomeMage,
+    name: 'Gnome Mage',
+    type: 'Minion',
+    cost: 2,
+    attack: 2,
+    health: 3,
+    effects: [
+      {
+        trigger: { type: 'SpellCast' },
+        action: { type: 'DrawCard', amount: 1 }
+      }
+    ]
+  },
+  [CARD_IDS.goblinAuctioneer]: {
+    id: CARD_IDS.goblinAuctioneer,
+    name: 'Goblin Auctioneer',
+    type: 'Minion',
+    cost: 6,
+    attack: 4,
+    health: 4,
+    effects: [
+      {
+        trigger: { type: 'SpellCast' },
+        action: { type: 'DrawCard', amount: 1 }
+      }
+    ]
+  },
+  [CARD_IDS.hiddenMage]: {
+    id: CARD_IDS.hiddenMage,
+    name: 'Hidden Mage',
+    type: 'Minion',
+    cost: 2,
+    attack: 2,
+    health: 2,
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Stealth' }
+      }
+    ]
+  },
+  [CARD_IDS.holyElf]: {
+    id: CARD_IDS.holyElf,
+    name: 'Holy Elf',
+    type: 'Minion',
+    cost: 3,
+    attack: 3,
+    health: 4,
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Heal', amount: 3, target: 'Hero' }
+      }
+    ]
+  },
+  [CARD_IDS.inferno]: {
+    id: CARD_IDS.inferno,
+    name: 'Inferno',
+    type: 'Minion',
+    cost: 7,
+    attack: 7,
+    health: 5,
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Damage', amount: 3, target: 'AllEnemies' }
+      }
+    ]
+  },
+  [CARD_IDS.joker]: {
+    id: CARD_IDS.joker,
+    name: 'Joker',
+    type: 'Minion',
+    cost: 3,
+    attack: 3,
+    health: 3,
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'DrawCard', amount: 2 }
+      }
+    ]
+  },
+  [CARD_IDS.kirintorMage]: {
+    id: CARD_IDS.kirintorMage,
+    name: 'Kirintor Mage',
+    type: 'Minion',
+    cost: 3,
+    attack: 4,
+    health: 3,
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Custom', key: 'Battlecry' }
+      }
+    ]
+  },
+  [CARD_IDS.knifJungler]: {
+    id: CARD_IDS.knifJungler,
+    name: 'Knif Jungler',
+    type: 'Minion',
+    cost: 2,
+    attack: 2,
+    health: 2,
+    effects: [
+      {
+        trigger: { type: 'Custom', key: 'AfterYouSummon' },
+        action: { type: 'Custom', key: 'RandomEnemyDamage', data: { amount: 1 } }
+      }
+    ]
+  },
+  [CARD_IDS.nightMorloc]: {
+    id: CARD_IDS.nightMorloc,
+    name: 'Night Morloc',
+    type: 'Minion',
+    cost: 3,
+    attack: 3,
+    health: 3
+  },
+  [CARD_IDS.pantera]: {
+    id: CARD_IDS.pantera,
+    name: 'Pantera',
+    type: 'Minion',
+    cost: 1,
+    attack: 2,
+    health: 1,
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Stealth' }
+      }
+    ]
+  },
+  [CARD_IDS.pirateGirl]: {
+    id: CARD_IDS.pirateGirl,
+    name: 'Pirate Girl',
+    type: 'Minion',
+    cost: 2,
+    attack: 2,
+    health: 2,
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Charge' }
+      }
+    ]
+  },
+  [CARD_IDS.pirateMan]: {
+    id: CARD_IDS.pirateMan,
+    name: 'Pirate Man',
+    type: 'Minion',
+    cost: 3,
+    attack: 3,
+    health: 3,
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Custom', key: 'Battlecry' }
+      }
+    ]
+  },
+  [CARD_IDS.pyromancer]: {
+    id: CARD_IDS.pyromancer,
+    name: 'Pyromancer',
+    type: 'Minion',
+    cost: 3,
+    attack: 3,
+    health: 3,
+    effects: [
+      {
+        trigger: { type: 'SpellCast' },
+        action: { type: 'Custom', key: 'DamageAllMinions', data: { amount: 1 } }
+      }
+    ]
+  },
+  [CARD_IDS.ravenholdtAssassin]: {
+    id: CARD_IDS.ravenholdtAssassin,
+    name: 'Ravenholdt Assassin',
+    type: 'Minion',
+    cost: 6,
+    attack: 7,
+    health: 5,
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Stealth' }
+      }
+    ]
+  },
+  [CARD_IDS.sandDefender]: {
+    id: CARD_IDS.sandDefender,
+    name: 'Sand Defender',
+    type: 'Minion',
+    cost: 4,
+    attack: 2,
+    health: 6,
+    effects: [
+      {
+        trigger: { type: 'Aura' },
+        action: { type: 'Custom', key: 'Taunt' }
+      }
+    ]
+  },
+  [CARD_IDS.scorpion]: {
+    id: CARD_IDS.scorpion,
+    name: 'Scorpion',
+    type: 'Minion',
+    cost: 4,
+    attack: 4,
+    health: 4
+  },
+  [CARD_IDS.shadowDrake]: {
+    id: CARD_IDS.shadowDrake,
+    name: 'Shadow Drake',
+    type: 'Minion',
+    cost: 5,
+    attack: 5,
+    health: 4,
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'DrawCard', amount: 1 }
+      }
+    ]
+  },
+  [CARD_IDS.taurenPrist]: {
+    id: CARD_IDS.taurenPrist,
+    name: 'Tauren Prist',
+    type: 'Minion',
+    cost: 5,
+    attack: 4,
+    health: 6,
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Heal', amount: 4, target: 'FriendlyMinion' }
+      }
+    ]
+  },
+  [CARD_IDS.waterMorlockSmall]: {
+    id: CARD_IDS.waterMorlockSmall,
+    name: 'Water Morlock',
+    type: 'Minion',
+    cost: 2,
+    attack: 2,
+    health: 3,
+    effects: [
+      {
+        trigger: { type: 'Battlecry' },
+        action: { type: 'Summon', cardId: CARD_IDS.wisp, count: 1, target: 'Board' }
+      }
+    ]
+  },
+
   // Classic set minions
   [CARD_IDS.abusiveSergeant]: {
     id: CARD_IDS.abusiveSergeant,

--- a/shared/constants.ts
+++ b/shared/constants.ts
@@ -15,36 +15,64 @@ export const STARTING_SEQ = 1;
 export const CARD_IDS = {
   // Demo originals
   argentSquare: 'card_argent_square',
+  abomination: 'card_abomination',
+  alchimist: 'card_alchimist',
+  bartender: 'card_bartender',
   berserk: 'card_berserk',
+  brainEaterZombi: 'card_brain_eater_zombi',
+  bubusDog: 'card_bubus_dog',
   bullguard: 'card_bullguard',
   cunningPeople: 'card_cunning_people',
   delivarer: 'card_delivarer',
+  draeneiWarrior: 'card_draenei_warrior',
   draugr: 'card_draugr',
+  dwarfBlacksmith: 'card_dwarf_blacksmith',
+  elfFireMage: 'card_elf_fire_mage',
   elunaPrist: 'card_eluna_prist',
   fairyLife: 'card_fairy_life',
   fireBeard: 'card_fire_beard',
   forestDweller: 'card_forest_dweller',
   frongProtector: 'card_frong_protector',
+  frostSpirit: 'card_frost_spirit',
   gatplank: 'card_gatplank',
   germesProtector: 'card_germes_protector',
+  gnomeMage: 'card_gnome_mage',
+  goblinAuctioneer: 'goblin_auctioneer',
+  hiddenMage: 'card_hidden_mage',
   hoarder: 'card_hoarder',
+  holyElf: 'card_holy_elf',
+  inferno: 'card_inferno',
+  joker: 'card_joker',
+  kirintorMage: 'card_kirintor_mage',
   knight: 'card_knight',
+  knifJungler: 'card_knif_jungler',
   lepraGnome: 'card_lepra_gnome',
   miniDragon: 'card_mini_dragon',
   nighOwl: 'card_nigh_owl',
+  nightMorloc: 'card_night_morloc',
   ninja: 'card_ninja',
+  pantera: 'card_pantera',
+  pirateGirl: 'card_pirate_girl',
+  pirateMan: 'card_pirate_man',
+  pyromancer: 'card_pyromancer',
   python: 'card_python',
+  ravenholdtAssassin: 'card_ravenholdt_assisn',
   raider: 'card_raider',
   sacredGargoyle: 'card_sacred_gargoyle',
   sage: 'card_sage',
+  sandDefender: 'card_sand_defender',
   sergeant: 'card_sergeant',
   shieldGuard: 'card_shield_guard',
+  scorpion: 'card_scorpion',
+  shadowDrake: 'card_shadow_drake',
   skeleton: 'card_skeleton',
   surtur: 'card_surtur',
+  taurenPrist: 'card_tauren_prist',
   tiger: 'card_tiger',
   vikingGirl: 'card_viking_girl',
   warrior: 'card_warrior',
   waterElemental: 'card_water_elemental',
+  waterMorlockSmall: 'card_water_morlock_small',
   wisp: 'card_wisp',
   wolf: 'card_wolf',
   worgen: 'card_worgen',
@@ -114,33 +142,48 @@ export const CARD_IDS = {
 export type DemoCardId = (typeof CARD_IDS)[keyof typeof CARD_IDS];
 export const DEFAULT_DECK: DemoCardId[] = [
   // 🔹 1 мана
-  CARD_IDS.argentSquare,  CARD_IDS.argentSquare,   // x2
-  CARD_IDS.bullguard,     CARD_IDS.bullguard,      // x2
-  CARD_IDS.lepraGnome,    CARD_IDS.lepraGnome,     // x2
-  CARD_IDS.wisp,          CARD_IDS.wisp,           // x2
+  CARD_IDS.argentSquare,
+  CARD_IDS.bubusDog,
+  CARD_IDS.bullguard,
+  CARD_IDS.cunningPeople,
+  CARD_IDS.pantera,
 
   // 🔹 2 маны
-  CARD_IDS.berserk,       CARD_IDS.berserk,        // x2
-  CARD_IDS.hoarder,       CARD_IDS.hoarder,        // x2
-  CARD_IDS.raider,        CARD_IDS.raider,         // x2
-  CARD_IDS.sergeant,      CARD_IDS.sergeant,       // x2
-  CARD_IDS.firebolt,      CARD_IDS.firebolt,       // x2
+  CARD_IDS.alchimist,
+  CARD_IDS.berserk,
+  CARD_IDS.firebolt,
+  CARD_IDS.gnomeMage,
+  CARD_IDS.heal,
+  CARD_IDS.waterMorlockSmall,
 
   // 🔹 3 маны
-  CARD_IDS.elunaPrist,    CARD_IDS.elunaPrist,     // x2
-  CARD_IDS.fireBeard,     CARD_IDS.fireBeard,      // x2
-  CARD_IDS.ninja,         CARD_IDS.ninja,          // x2
-  CARD_IDS.wolf,          CARD_IDS.wolf,           // x2
-  CARD_IDS.heal,          CARD_IDS.heal,           // x2
+  CARD_IDS.bartender,
+  CARD_IDS.fireBeard,
+  CARD_IDS.frostSpirit,
+  CARD_IDS.joker,
+  CARD_IDS.pyromancer,
 
   // 🔹 4 маны
-  CARD_IDS.knight,        CARD_IDS.shieldGuard,    // по 1 копии
-  CARD_IDS.knight,        CARD_IDS.shieldGuard,    // по 2 копии итого
+  CARD_IDS.draeneiWarrior,
+  CARD_IDS.dwarfBlacksmith,
+  CARD_IDS.elfFireMage,
+  CARD_IDS.knight,
+  CARD_IDS.sandDefender,
 
-  // 🔹 5–6 маны
+  // 🔹 5 маны
   CARD_IDS.miniDragon,
-  CARD_IDS.worgen,
+  CARD_IDS.shadowDrake,
+  CARD_IDS.taurenPrist,
+
+  // 🔹 6 маны
+  CARD_IDS.abomination,
+  CARD_IDS.goblinAuctioneer,
+  CARD_IDS.ravenholdtAssassin,
   CARD_IDS.tiger,
+
+  // 🔹 7 маны
+  CARD_IDS.inferno,
+  CARD_IDS.stormwindChampion,
 
   // Coin (не включаем — карта выдаётся второму игроку автоматически)
 ];


### PR DESCRIPTION
## Summary
- register every card art asset in `CARD_IDS` and flesh out missing demo minions so each identifier has a definition
- refresh the default demo deck to draw from the expanded pool, sorted by mana cost

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e54dea843c83299ffceadf7f536390